### PR TITLE
Fix missing os import in deformable mirror script

### DIFF
--- a/src/create_deformable_mirror.py
+++ b/src/create_deformable_mirror.py
@@ -9,6 +9,7 @@ from matplotlib import pyplot as plt
 from hcipy import *
 from PIL import Image
 import numpy as np
+import os
 
 # Set the Working Directory
 os.chdir('/home/laboptic/Documents/optlab-master/PROJECTS_3/RISTRETTO/Banc AO')


### PR DESCRIPTION
## Summary
- add missing `import os` in `create_deformable_mirror.py`

## Testing
- `python -m py_compile src/create_deformable_mirror.py`

------
https://chatgpt.com/codex/tasks/task_e_68518e6b10c48330aae452ff3e79ff49