### PR TITLE
Add path configuration to dao_setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # AObench
 The AO bench code to test the pyramid wavefront sensor
+
+## Configuration
+
+The repository relies on `dao_setup.py` for initializing hardware and paths. By
+default paths are based on `/home/ristretto-dao/optlab-master`, but you can
+override them using environment variables:
+
+```
+export OPT_LAB_ROOT=/path/to/optlab-master
+export PROJECT_ROOT=/path/to/project
+```
+
+These variables allow running the code from different locations without
+modifying the source files. Output directories are created under
+`PROJECT_ROOT`, which defaults to `${OPT_LAB_ROOT}/PROJECTS_3/RISTRETTO/Banc AO`.

--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -15,27 +15,34 @@ import time
 from astropy.io import fits
 import os
 import dao
-from skimage.transform import resize  
+from skimage.transform import resize
+from pathlib import Path
+import sys
 
-# Set the working directory
-os.chdir('/home/ristretto-dao/optlab-master')
+# Configure root directories using environment variables with reasonable defaults
+OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
+PROJECT_ROOT = Path(
+    os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO")
+)
+
+# Ensure required modules are importable without changing the working directory
+sys.path.append(str(OPT_LAB_ROOT))
+sys.path.append(str(PROJECT_ROOT))
+
 from DEVICES_3.Basler_Pylon.test_pylon import *
 from DEVICES_3.Thorlabs.MCLS1 import mcls1
-
-# Set the working directory
-os.chdir('/home/ristretto-dao/optlab-master/PROJECTS_3/RISTRETTO/Banc AO/')
 
 # Import specific modules
 from src.create_circular_pupil import *
 from src.tilt import *
 from src.utils import *
 
-ROOT_DIR = '/home/ristretto-dao/optlab-master/PROJECTS_3/RISTRETTO/Banc AO/'
-folder_calib = os.path.join(ROOT_DIR, 'outputs/Calibration_files')
-folder_pyr_mask = os.path.join(ROOT_DIR, 'outputs/3s_pyr_mask')
-folder_transformation_matrices = os.path.join(ROOT_DIR, 'outputs/Transformation_matrices')
-folder_closed_loop_tests = os.path.join(ROOT_DIR, 'outputs/Closed_loop_tests')
-folder_turbulence = os.path.join(ROOT_DIR, 'outputs/Phase_screens')
+ROOT_DIR = PROJECT_ROOT
+folder_calib = ROOT_DIR / "outputs/Calibration_files"
+folder_pyr_mask = ROOT_DIR / "outputs/3s_pyr_mask"
+folder_transformation_matrices = ROOT_DIR / "outputs/Transformation_matrices"
+folder_closed_loop_tests = ROOT_DIR / "outputs/Closed_loop_tests"
+folder_turbulence = ROOT_DIR / "outputs/Phase_screens"
 #%% Start the laser
 
 channel = 1


### PR DESCRIPTION
## Summary
- let dao_setup configure root paths from environment variables
- document new environment variables in README
- remove DAO_ROOT_DIR env var so outputs mirror `PROJECT_ROOT`

## Testing
- `python -m py_compile src/dao_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_68519349027483308c2fa034de9c836c