### PR TITLE
Add averaged calibration runs

### DIFF
--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -236,8 +236,18 @@ plt.show()
 
 #%%
 phase_amp = 0.1
-response_matrix_full, response_matrix_filtered = create_response_matrix(KL2Act, phase_amp, reference_image, mask,
-                                              verbose=True, verbose_plot=False)
+# Number of times to repeat the whole calibration
+n_calibration_repetitions = 1
+
+response_matrix_full, response_matrix_filtered = create_response_matrix(
+    KL2Act,
+    phase_amp,
+    reference_image,
+    mask,
+    verbose=True,
+    verbose_plot=False,
+    calibration_repetitions=n_calibration_repetitions,
+)
 
 #response_matrix_filtered = response_matrix_full[:, mask.ravel() > 0]
 


### PR DESCRIPTION
## Summary
- average response matrices over multiple calibration cycles
- expose number of calibration runs in calibration script
- rename argument to `calibration_repetitions`
- compute response matrix after averaging push-pull images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d3ebdec248330ab8a35887d476baf