### PR TITLE
Refactor PSF centring algorithm

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -123,33 +123,52 @@ zernike_basis = make_zernike_basis(11, pupil_size, pupil_grid)
 zernike_basis = [mode / np.ptp(mode) for mode in zernike_basis]
 zernike_basis = np.asarray(zernike_basis)
 
-# [-0.0813878287964559, 0.09992195172893337, 0.4] 
-# Create a Tip, Tilt, and Focus (TTF) matrix with specified amplitudes as the diagonal elements
-ttf_amplitudes = [-1.6667823542306033, 0.13384915911398743, 0.4] # Tip, Tilt, and Focus amplitudes - Focus 0.4
+# [-0.0813878287964559, 0.09992195172893337]
+# Create a Tip-Tilt (TT) matrix with specified amplitudes as the diagonal elements
+ttf_amplitudes = [-1.6667823542306033, 0.13384915911398743]  # Tip and Tilt amplitudes
 ttf_amplitude_matrix = np.diag(ttf_amplitudes)
-ttf_matrix = ttf_amplitude_matrix @ zernike_basis[1:4, :]  # Select modes 1 (tip), 2 (tilt), and 3 (focus)
+ttf_matrix = ttf_amplitude_matrix @ zernike_basis[1:3, :]  # Select modes 1 (tip) and 2 (tilt)
 
 data_ttf = np.zeros((dataHeight, dataWidth), dtype=np.float32)
-data_ttf[:, :] = (ttf_matrix[0] + ttf_matrix[1] + ttf_matrix[2]).reshape(dataHeight, dataWidth) 
+data_ttf[:, :] = (ttf_matrix[0] + ttf_matrix[1]).reshape(dataHeight, dataWidth)
 
-othermodes_amplitudes = [0, 0, 0, 0, 0, 0, 0] #Mode 4 to mode 10
+othermodes_amplitudes = [0.4, 0, 0, 0, 0, 0, 0, 0]  # Focus (mode 3) + modes 4 to 10
 othermodes_amplitude_matrix = np.diag(othermodes_amplitudes)
-othermodes_matrix = othermodes_amplitude_matrix @ zernike_basis[4:11, :]  # Select modes 4 to 10
+othermodes_matrix = othermodes_amplitude_matrix @ zernike_basis[3:11, :]  # Select modes 3 (focus) to 10
 
 data_othermodes = np.zeros((dataHeight, dataWidth), dtype=np.float32)
 data_othermodes[:, :] = (othermodes_matrix[0] + othermodes_matrix[1] + othermodes_matrix[2]).reshape(dataHeight, dataWidth) 
 
 # Add all the modes to data pupil
-data_pupil = data_pupil + data_ttf + data_othermodes# Add TTF matrix to pupil
+data_pupil = data_pupil + data_ttf + data_othermodes  # Add TT and higher-order terms to pupil
 
 
-# Function to update pupil with new TTF amplitude
-def update_pupil(new_ttf_amplitudes=None, new_tilt_amp_outer=None, new_tilt_amp_inner=None):
-    global ttf_amplitudes, tilt_amp_outer, tilt_amp_inner, data_pupil
+# Function to update pupil with new TT amplitudes and other modes
+def update_pupil(new_ttf_amplitudes=None, new_othermodes_amplitudes=None,
+                 new_tilt_amp_outer=None, new_tilt_amp_inner=None):
+    """Recompute the pupil using updated tip/tilt and higher-order amplitudes.
+
+    Parameters
+    ----------
+    new_ttf_amplitudes : sequence of float, optional
+        Two-element list ``[tip, tilt]`` for the TT matrix.
+    new_othermodes_amplitudes : sequence of float, optional
+        Amplitudes for focus and higher-order Zernike modes
+        (e.g., ``[focus, astig_x, astig_y, ...]``).
+    new_tilt_amp_outer : float, optional
+        Outer grating tilt amplitude.
+    new_tilt_amp_inner : float, optional
+        Inner grating tilt amplitude.
+    """
+    global ttf_amplitudes, othermodes_amplitudes
+    global tilt_amp_outer, tilt_amp_inner, data_pupil
 
     # Update the amplitudes and tilt parameters if new values are provided
     if new_ttf_amplitudes is not None:
-        ttf_amplitudes = np.diag(new_ttf_amplitudes)
+        ttf_amplitudes = list(new_ttf_amplitudes)
+
+    if new_othermodes_amplitudes is not None:
+        othermodes_amplitudes = list(new_othermodes_amplitudes)
 
     if new_tilt_amp_outer is not None:
         tilt_amp_outer = new_tilt_amp_outer
@@ -158,17 +177,23 @@ def update_pupil(new_ttf_amplitudes=None, new_tilt_amp_outer=None, new_tilt_amp_
         tilt_amp_inner = new_tilt_amp_inner
 
     # Recalculate pupil with updated values
-    data_pupil = create_slm_circular_pupil(tilt_amp_outer, tilt_amp_inner, pupil_size, pupil_mask, slm)
+    data_pupil = create_slm_circular_pupil(tilt_amp_outer, tilt_amp_inner,
+                                           pupil_size, pupil_mask, slm)
 
-    # Create a new Tip, Tilt, and Focus (TTF) matrix with the updated amplitudes
-    ttf_matrix = ttf_amplitudes @ zernike_basis[1:4, :]  # Select modes 1 (tip), 2 (tilt), and 3 (focus)
+    # Create a new Tip-Tilt (TT) matrix with the updated amplitudes
+    ttf_matrix = np.diag(ttf_amplitudes) @ zernike_basis[1:3, :]  # Select modes 1 (tip) and 2 (tilt)
     
-    # Create TTF data
+    # Create TT data
     data_ttf = np.zeros((dataHeight, dataWidth), dtype=np.float32)
-    data_ttf[:, :] = (ttf_matrix[0] + ttf_matrix[1] + ttf_matrix[2]).reshape(dataHeight, dataWidth)
+    data_ttf[:, :] = (ttf_matrix[0] + ttf_matrix[1]).reshape(dataHeight, dataWidth)
 
-    # Add the new TTF to the pupil and return
-    return data_pupil + data_ttf
+    # Recompute focus and higher-order terms
+    othermodes_matrix = np.diag(othermodes_amplitudes) @ zernike_basis[3:11, :]
+    data_othermodes = np.zeros((dataHeight, dataWidth), dtype=np.float32)
+    data_othermodes[:, :] = (othermodes_matrix[0] + othermodes_matrix[1] + othermodes_matrix[2]).reshape(dataHeight, dataWidth)
+
+    # Add the new TT and other modes to the pupil and return
+    return data_pupil + data_ttf + data_othermodes
 
 #%% Create a pupil grid for a smaller pupil area
 


### PR DESCRIPTION
## Summary
- simplify `cost_function` by dropping the explicit focus amplitude
- update `center_psf_on_pyramid_tip` to optimise only tip and tilt
- adjust example and documentation accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e33fc54448330aec7c2656a554d40