### PR TITLE
Fix for scan_othermode_amplitudes

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -225,7 +225,10 @@ othermodes_amplitudes = [0.006249999999999881, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 othermodes_amplitude_matrix = np.diag(othermodes_amplitudes)
 othermodes_matrix = othermodes_amplitude_matrix @ KL2Act[2:10, :]  # Select modes 3 (focus) to 10
 
-data_othermodes = (othermodes_matrix[0] + othermodes_matrix[1] + othermodes_matrix[2]).reshape(nact**2)
+# Sum all higher-order mode contributions.  The previous implementation
+# only added the first three rows, which meant modes beyond focus were
+# ignored.
+data_othermodes = np.sum(othermodes_matrix, axis=0).reshape(nact**2)
 
 #Put the modes on the dm
 data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
@@ -300,7 +303,9 @@ def update_pupil(new_tt_amplitudes=None, new_othermodes_amplitudes=None,
 
     # Recompute focus and higher-order terms
     othermodes_matrix = np.diag(othermodes_amplitudes) @ KL2Act[2:10, :]
-    data_othermodes = (othermodes_matrix[0] + othermodes_matrix[1] + othermodes_matrix[2])
+    # Include contributions from all provided modes instead of just the first
+    # three rows of the transformation matrix.
+    data_othermodes = np.sum(othermodes_matrix, axis=0)
         
     #Put the modes on the dm
     data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)

--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -49,23 +49,12 @@ def scan_othermode_amplitudes(test_values, mode_index, wait=wait_time,
         new_amps = list(othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        pupil = update_pupil(new_othermodes_amplitudes=new_amps)
-
-        pupil_outer = np.copy(pupil)
-        pupil_outer[pupil_mask] = 0
-
-        pupil_inner = np.copy(
-            pupil[offset_height:offset_height + npix_small_pupil_grid,
-                  offset_width:offset_width + npix_small_pupil_grid]
-        )
-        pupil_inner[~small_pupil_mask] = 0
-
-        slm_data = compute_data_slm(
-            data_pupil_inner=pupil_inner,
-            data_pupil_outer=pupil_outer,
-            pupil_mask=pupil_mask,
-            small_pupil_mask=small_pupil_mask,
-        )
+        # ``update_pupil`` already recomputes the pupil and returns the
+        # SLM array.  The previous implementation attempted to treat the
+        # returned value as the pupil itself which resulted in incorrect
+        # slicing and shape errors.  We only need to call ``update_pupil``
+        # and send its result directly to the SLM.
+        slm_data = update_pupil(new_othermodes_amplitudes=new_amps)
         slm.set_data(slm_data)
         time.sleep(wait)
 


### PR DESCRIPTION
## Summary
- fix call to `update_pupil` in `scan_othermode_amplitudes`
- sum all higher-order modes in `update_pupil`

## Testing
- `python -m py_compile src/scan_modes_functions.py src/dao_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_687591f89e488330b613c93dd64c42a4