### PR TITLE
Add WFS std amplitude scan

### DIFF
--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -5,16 +5,12 @@ from src.dao_setup import (
     wait_time,
     othermodes_amplitudes,
     update_pupil,
-    pupil_mask,
-    small_pupil_mask,
-    offset_height,
-    offset_width,
-    npix_small_pupil_grid,
     camera_fp,
+    camera_wfs,
     slm,
     ROOT_DIR,
 )
-from src.utils import compute_data_slm
+from src.create_shared_memories import valid_pixels_mask_shm
 from pathlib import Path
 import re
 
@@ -73,6 +69,84 @@ def scan_othermode_amplitudes(test_values, mode_index, wait=wait_time,
         best_amp = None
 
     print(f"Best amplitude {best_amp:.3f} with max intensity {best_intensity:.3f}")
+
+    if update_setup_file and best_amp is not None:
+        dao_setup_path = Path(ROOT_DIR) / 'src/dao_setup.py'
+        with open(dao_setup_path, 'r') as file:
+            content = file.read()
+
+        match = re.search(r"othermodes_amplitudes\s*=\s*\[(.*?)\]", content)
+        if match:
+            values = [float(v.strip()) for v in match.group(1).split(',')]
+            if mode_index >= len(values):
+                raise ValueError('mode_index out of range in dao_setup.py')
+            values[mode_index] = best_amp
+            new_line = f"othermodes_amplitudes = {values}"
+            updated_content = re.sub(r"othermodes_amplitudes\s*=\s*\[.*?\]", new_line, content)
+            with open(dao_setup_path, 'w') as file:
+                file.write(updated_content)
+            print('Updated `othermodes_amplitudes` in dao_setup.py')
+        else:
+            print('Failed to update `othermodes_amplitudes` in dao_setup.py')
+
+
+def scan_othermode_amplitudes_wfs_std(test_values, mode_index, wait=wait_time,
+                                      update_setup_file=False):
+    """Iterate over amplitude values for a specified othermode using WFS data.
+
+    This variant captures images from the wavefront sensor camera and
+    minimizes the standard deviation of valid pixels within the mask.
+
+    Parameters
+    ----------
+    test_values : sequence of float
+        Amplitude values to test.
+    mode_index : int
+        Index in ``othermodes_amplitudes`` to update.
+    wait : float, optional
+        Delay between successive SLM updates. Defaults to ``wait_time``.
+    update_setup_file : bool, optional
+        If True, update ``othermodes_amplitudes`` in ``dao_setup.py`` with
+        the best-performing amplitude. If multiple amplitudes yield the same
+        minimum standard deviation, their mean value is stored.
+    """
+
+    if mode_index < 0 or mode_index >= len(othermodes_amplitudes):
+        raise ValueError(
+            f"mode_index must be between 0 and {len(othermodes_amplitudes) - 1}"
+        )
+
+    best_amps = []
+    best_std = np.inf
+
+    for amp in test_values:
+        new_amps = list(othermodes_amplitudes)
+        new_amps[mode_index] = amp
+
+        slm_data = update_pupil(new_othermodes_amplitudes=new_amps)
+        slm.set_data(slm_data)
+        time.sleep(wait)
+
+        # Capture WFS images and compute standard deviation over valid pixels
+        num_images = 5
+        images = [camera_wfs.get_data() for _ in range(num_images)]
+        wfs_img = np.mean(images, axis=0)
+        mask = valid_pixels_mask_shm.get_data().astype(bool)
+        pixel_std = np.std(wfs_img[mask])
+        print(f"Amplitude {amp:.3f} -> std of valid pixels {pixel_std:.3f}")
+
+        if pixel_std < best_std:
+            best_std = pixel_std
+            best_amps = [amp]
+        elif np.isclose(pixel_std, best_std, rtol=0, atol=1e-9):
+            best_amps.append(amp)
+
+    if best_amps:
+        best_amp = float(np.mean(best_amps))
+    else:
+        best_amp = None
+
+    print(f"Best amplitude {best_amp:.3f} with min std {best_std:.3f}")
 
     if update_setup_file and best_amp is not None:
         dao_setup_path = Path(ROOT_DIR) / 'src/dao_setup.py'


### PR DESCRIPTION
## Summary
- measure focal plane intensity in `scan_othermode_amplitudes`
- add `scan_othermode_amplitudes_wfs_std` that minimizes WFS standard deviation
- clean up unused imports

## Testing
- `python -m py_compile src/scan_modes_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_68759964db2c8330b918c56278d9fb20