### PR TITLE
Encapsulate pupil update logic

### DIFF
--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -19,8 +19,13 @@ sys.path.append(str(OPT_LAB_ROOT))
 sys.path.append(str(PROJECT_ROOT))
 ROOT_DIR = PROJECT_ROOT
 
-from src.dao_setup import *  # Import all variables from setup
-#import src.dao_setup as dao_setup
+from src.dao_setup import (
+    wait_time,
+    pupil_setup,
+    camera_wfs,
+    slm,
+    ROOT_DIR,
+)
 
 
 # Access the SLM and cameras
@@ -57,7 +62,7 @@ def cost_function(amplitudes, pupil_coords, radius, iteration, variance_threshol
     """
     global stop_optimization  #Flag to stop when pupil intensities are equal
 
-    data_slm = update_pupil(new_tt_amplitudes=amplitudes)
+    data_slm = pupil_setup.update_pupil(new_tt_amplitudes=amplitudes)
     slm.set_data(data_slm)  # Update SLM data
     time.sleep(wait_time)  # Wait for the update to take effect
 

--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -3,8 +3,7 @@ import numpy as np
 
 from src.dao_setup import (
     wait_time,
-    othermodes_amplitudes,
-    update_pupil,
+    pupil_setup,
     camera_fp,
     camera_wfs,
     slm,
@@ -32,19 +31,19 @@ def scan_othermode_amplitudes(test_values, mode_index, wait=wait_time,
         achieve the same maximum intensity, their mean value is stored.
     """
 
-    if mode_index < 0 or mode_index >= len(othermodes_amplitudes):
+    if mode_index < 0 or mode_index >= len(pupil_setup.othermodes_amplitudes):
         raise ValueError(
-            f"mode_index must be between 0 and {len(othermodes_amplitudes) - 1}"
+            f"mode_index must be between 0 and {len(pupil_setup.othermodes_amplitudes) - 1}"
         )
 
     best_amps = []
     best_intensity = -np.inf
 
     for amp in test_values:
-        new_amps = list(othermodes_amplitudes)
+        new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        slm_data = update_pupil(new_othermodes_amplitudes=new_amps)
+        slm_data = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
         slm.set_data(slm_data)
         time.sleep(wait)
 
@@ -110,19 +109,19 @@ def scan_othermode_amplitudes_wfs_std(test_values, mode_index, mask, wait=wait_t
         minimum standard deviation, their mean value is stored.
     """
 
-    if mode_index < 0 or mode_index >= len(othermodes_amplitudes):
+    if mode_index < 0 or mode_index >= len(pupil_setup.othermodes_amplitudes):
         raise ValueError(
-            f"mode_index must be between 0 and {len(othermodes_amplitudes) - 1}"
+            f"mode_index must be between 0 and {len(pupil_setup.othermodes_amplitudes) - 1}"
         )
 
     best_amps = []
     best_std = np.inf
 
     for amp in test_values:
-        new_amps = list(othermodes_amplitudes)
+        new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        slm_data = update_pupil(new_othermodes_amplitudes=new_amps)
+        slm_data = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
         slm.set_data(slm_data)
         time.sleep(wait)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -16,7 +16,7 @@ import src.dao_setup as dao_setup
 
 # Add and wrap data within the pupil mask
 
-def compute_data_slm(data_dm=0, data_phase_screen=0, **kwargs):
+def compute_data_slm(data_dm=0, data_phase_screen=0, setup=None, **kwargs):
     """
     Computes the SLM data by combining phase screen and deformable mirror data
     with pupil-related masks and arrays.
@@ -34,10 +34,16 @@ def compute_data_slm(data_dm=0, data_phase_screen=0, **kwargs):
     - data_slm (ndarray): Resulting SLM data.
     """
     
-    data_pupil_inner = kwargs.get("data_pupil_inner", dao_setup.data_pupil_inner_new)
-    data_pupil_outer = kwargs.get("data_pupil_outer", dao_setup.data_pupil_outer)
-    pupil_mask = kwargs.get("pupil_mask", dao_setup.pupil_mask)
-    small_pupil_mask = kwargs.get("small_pupil_mask", dao_setup.small_pupil_mask)
+    if setup is None:
+        data_pupil_inner = kwargs.get("data_pupil_inner", dao_setup.data_pupil_inner_new)
+        data_pupil_outer = kwargs.get("data_pupil_outer", dao_setup.data_pupil_outer)
+        pupil_mask = kwargs.get("pupil_mask", dao_setup.pupil_mask)
+        small_pupil_mask = kwargs.get("small_pupil_mask", dao_setup.small_pupil_mask)
+    else:
+        data_pupil_inner = kwargs.get("data_pupil_inner", setup.data_pupil_inner_new)
+        data_pupil_outer = kwargs.get("data_pupil_outer", setup.data_pupil_outer)
+        pupil_mask = kwargs.get("pupil_mask", setup.pupil_mask)
+        small_pupil_mask = kwargs.get("small_pupil_mask", setup.small_pupil_mask)
 
     data_slm = data_pupil_outer.copy()
     data_inner = (((data_pupil_inner + data_dm + data_phase_screen) * 256) % 256)


### PR DESCRIPTION
## Summary
- refactor `dao_setup` by introducing `PupilSetup` class
- support using `PupilSetup` instance in `compute_data_slm`
- update utilities to use the new class

## Testing
- `python3 -m py_compile src/utils.py src/dao_setup.py src/scan_modes_functions.py src/psf_centring_algorithm_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_68784ed922fc8330ba1a52c732b18dea