### PR TITLE
Introduce config and hardware classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ The AO bench code to test the pyramid wavefront sensor
 
 ## Configuration
 
-The repository relies on `dao_setup.py` for initializing hardware and paths. By
-default paths are based on `/home/ristretto-dao/optlab-master`, but you can
-override them using environment variables:
+The repository relies on `src/config.py` and `dao_setup.py` for initializing
+hardware and paths. By default paths are based on `/home/ristretto-dao/optlab-master`,
+but you can override them using environment variables:
 
 ```
 export OPT_LAB_ROOT=/path/to/optlab-master

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import os
+import sys
+
+class Config:
+    """Central configuration of file system paths."""
+
+    def __init__(self):
+        self.opt_lab_root = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
+        self.project_root = Path(os.environ.get("PROJECT_ROOT", self.opt_lab_root / "PROJECTS_3/RISTRETTO/Banc AO"))
+        # Ensure modules in optlab and project can be imported
+        sys.path.append(str(self.opt_lab_root))
+        sys.path.append(str(self.project_root))
+        self.root_dir = self.project_root
+
+        # Pre-compute commonly used output folders
+        self.folder_calib = self.root_dir / 'outputs/Calibration_files'
+        self.folder_pyr_mask = self.root_dir / 'outputs/3s_pyr_mask'
+        self.folder_transformation_matrices = self.root_dir / 'outputs/Transformation_matrices'
+        self.folder_closed_loop_tests = self.root_dir / 'outputs/Closed_loop_tests'
+        self.folder_turbulence = self.root_dir / 'outputs/Phase_screens'
+        self.folder_gui = self.root_dir / 'outputs/GUI_tests'
+
+config = Config()

--- a/src/create_deformable_mirror.py
+++ b/src/create_deformable_mirror.py
@@ -13,12 +13,9 @@ import os
 import sys
 from pathlib import Path
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
+
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from src.tilt import *

--- a/src/create_phase_screens.py
+++ b/src/create_phase_screens.py
@@ -83,19 +83,16 @@ plt.show()
 
 #%%
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
+
+ROOT_DIR = config.root_dir
 
 # Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
+folder_calib = config.folder_calib
+folder_pyr_mask = config.folder_pyr_mask
+folder_transformation_matrices = config.folder_transformation_matrices
+folder_closed_loop_tests = config.folder_closed_loop_tests
+folder_turbulence = config.folder_turbulence
 
 
 # Define parameters

--- a/src/create_shared_memories.py
+++ b/src/create_shared_memories.py
@@ -4,12 +4,9 @@ import os
 import sys
 from pathlib import Path
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
+
+ROOT_DIR = config.root_dir
 
 # Explicit imports from dao_setup
 from src.dao_setup import (npix_small_pupil_grid, dataHeight, dataWidth, 

--- a/src/create_transformation_matrices.py
+++ b/src/create_transformation_matrices.py
@@ -14,13 +14,9 @@ import numpy as np
 import os
 import sys
 
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao

--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -24,12 +24,10 @@ import matplotlib.animation as animation
 from pathlib import Path
 from skimage.transform import resize
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
+from src.hardware import Camera, SLM, Laser
+
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from DEVICES_3.Thorlabs.MCLS1 import mcls1
@@ -43,27 +41,26 @@ from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenMod
 from src.transformation_matrices_functions import *
 
 
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
-folder_gui = ROOT_DIR / 'outputs/GUI_tests'
+folder_calib = config.folder_calib
+folder_pyr_mask = config.folder_pyr_mask
+folder_transformation_matrices = config.folder_transformation_matrices
+folder_closed_loop_tests = config.folder_closed_loop_tests
+folder_turbulence = config.folder_turbulence
+folder_gui = config.folder_gui
 
 #%% Start the laser
 
 channel = 1
-las = mcls1("/dev/ttyUSB0")
-las.set_channel(channel)
-#las.enable(1) # 1 to turn on laser, 0 to turn off
-las.set_current(49) #55mA is a good value for pyramid images
+las = Laser("/dev/ttyUSB0", channel)
+# las.enable(1)  # 1 to turn on laser, 0 to turn off
+las.set_current(49)  # 55mA is a good value for pyramid images
 print('Laser is Accessible')
   
 #%% Configuration Camera
 
 # To set camera
-camera_wfs = dao.shm('/tmp/cam1.im.shm')
-camera_fp = dao.shm('/tmp/cam2.im.shm')
+camera_wfs = Camera('/tmp/cam1.im.shm')
+camera_fp = Camera('/tmp/cam2.im.shm')
 
 fps_wfs = dao.shm('/tmp/cam1Fps.im.shm')
 fps_wfs.set_data(fps_wfs.get_data()*0+300)
@@ -84,7 +81,7 @@ img_size_fp_cam = img_fp.shape[0]
 #%% Configuration SLM
 
 # Initializes the SLM library
-slm=dao.shm('/tmp/slm.im.shm')
+slm = SLM('/tmp/slm.im.shm')
 print('SLM is open')
 
 # Get SLM dimensions

--- a/src/dao_setup_trial.py
+++ b/src/dao_setup_trial.py
@@ -32,12 +32,9 @@ import matplotlib.animation as animation
 from pathlib import Path
 from skimage.transform import resize
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
+
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from DEVICES_3.Thorlabs.MCLS1 import mcls1
@@ -51,12 +48,12 @@ from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenMod
 from src.transformation_matrices_functions import *
 
 
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
-folder_gui = ROOT_DIR / 'outputs/GUI_tests'
+folder_calib = config.folder_calib
+folder_pyr_mask = config.folder_pyr_mask
+folder_transformation_matrices = config.folder_transformation_matrices
+folder_closed_loop_tests = config.folder_closed_loop_tests
+folder_turbulence = config.folder_turbulence
+folder_gui = config.folder_gui
 
 #%% Start the laser
 

--- a/src/hardware.py
+++ b/src/hardware.py
@@ -1,0 +1,25 @@
+import dao
+from DEVICES_3.Thorlabs.MCLS1 import mcls1
+
+class ShmWrapper:
+    """Simple wrapper exposing the underlying dao.shm object."""
+    def __init__(self, shm_path):
+        self.shm = dao.shm(shm_path)
+
+    def __getattr__(self, attr):
+        return getattr(self.shm, attr)
+
+class Camera(ShmWrapper):
+    pass
+
+class SLM(ShmWrapper):
+    pass
+
+class Laser:
+    """Thin wrapper around the Thorlabs MCLS1 laser."""
+    def __init__(self, port="/dev/ttyUSB0", channel=1):
+        self.dev = mcls1(port)
+        self.dev.set_channel(channel)
+
+    def __getattr__(self, attr):
+        return getattr(self.dev, attr)

--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -12,12 +12,9 @@ from pathlib import Path
 import cv2
 import re
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
+
+ROOT_DIR = config.root_dir
 
 from src.dao_setup import (
     wait_time,

--- a/src/thorlabs_laser.py
+++ b/src/thorlabs_laser.py
@@ -8,13 +8,10 @@ import os
 import sys
 from pathlib import Path
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
 from DEVICES_3.Thorlabs.MCLS1 import mcls1
+
+ROOT_DIR = config.root_dir
 
 channel = 1
 state = 0 # 0 to turn OFF, 1 to turn ON

--- a/src/transformation_matrices_functions.py
+++ b/src/transformation_matrices_functions.py
@@ -16,19 +16,16 @@ from src.utils import *
 import sys
 from pathlib import Path
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+from src.config import config
+
+ROOT_DIR = config.root_dir
 
 # Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
+folder_calib = config.folder_calib
+folder_pyr_mask = config.folder_pyr_mask
+folder_transformation_matrices = config.folder_transformation_matrices
+folder_closed_loop_tests = config.folder_closed_loop_tests
+folder_turbulence = config.folder_turbulence
 
 # Default folder for storing transformation matrices
 


### PR DESCRIPTION
## Summary
- add central `config` module for root path management
- create `hardware` module with simple wrappers for camera, SLM and laser
- use these utilities across setup and other modules
- document new config module in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68785c1de6d4833094892252e4c9f8ac