### PR TITLE
Refactor DAO scripts to use config paths

### DIFF
--- a/scripts_with_dao/comparing_oomao_hcipy_turbulence.py
+++ b/scripts_with_dao/comparing_oomao_hcipy_turbulence.py
@@ -19,20 +19,9 @@ from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 import matplotlib.animation as animation
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
-
-# Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from src.create_circular_pupil import *

--- a/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
@@ -22,13 +22,9 @@ import sys
 import scipy
 import matplotlib.animation as animation
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao

--- a/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
@@ -24,20 +24,9 @@ from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 import matplotlib.animation as animation
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
-
-# Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from src.create_circular_pupil import *

--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -23,13 +23,9 @@ import scipy
 import matplotlib.animation as animation
 from pathlib import Path
 from datetime import datetime
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao

--- a/scripts_with_dao/dao_cross_correlation_3s_pyr.py
+++ b/scripts_with_dao/dao_cross_correlation_3s_pyr.py
@@ -22,21 +22,10 @@ import scipy
 from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
-
-# Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
-folder_linearity = ROOT_DIR / 'outputs/Linearity_check'
+ROOT_DIR = config.root_dir
+folder_linearity = config.root_dir / 'outputs/Linearity_check'
 
 # Import Specific Modules
 from src.create_circular_pupil import *

--- a/scripts_with_dao/dao_implement_slm_pupil.py
+++ b/scripts_with_dao/dao_implement_slm_pupil.py
@@ -17,13 +17,9 @@ import os
 import sys
 from DEVICES_3.Basler_Pylon.test_pylon import * # import library for camera functions
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import specific modules
 from src.dao_setup import *  # Import all variables from setup

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -23,13 +23,9 @@ from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 from matplotlib.colors import LogNorm
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao

--- a/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
@@ -20,20 +20,9 @@ import scipy
 from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
-
-# Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from src.create_circular_pupil import *

--- a/scripts_with_dao/dao_push-pull_calibration_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_kl_3s_pyr.py
@@ -22,13 +22,9 @@ import sys
 import scipy
 import matplotlib.animation as animation
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from DEVICES_3.Basler_Pylon.test_pylon import *
@@ -41,12 +37,6 @@ from src.dao_setup import *  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *
 from src.ao_loop import *
-
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
 
 #%% Creating and Displaying a Circular Pupil on the SLM
 

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
@@ -20,20 +20,9 @@ import scipy
 from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
-
-# Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from src.create_circular_pupil import *

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
@@ -28,13 +28,9 @@ import scipy
 from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from src.create_circular_pupil import *

--- a/scripts_with_dao/dao_test_DM_units.py
+++ b/scripts_with_dao/dao_test_DM_units.py
@@ -2,13 +2,9 @@ import os
 import sys
 from pathlib import Path
 from matplotlib import pyplot as plt
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao

--- a/scripts_with_dao/dao_testing_DM_tip_tilt.py
+++ b/scripts_with_dao/dao_testing_DM_tip_tilt.py
@@ -17,13 +17,9 @@ import sys
 import scipy
 from pathlib import Path
 from datetime import datetime
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao

--- a/scripts_with_dao/dao_transformation_matrices.py
+++ b/scripts_with_dao/dao_transformation_matrices.py
@@ -19,13 +19,9 @@ from hcipy import *
 import dao
 import sys
 from pathlib import Path
+from src.config import config
 
-# Configure root paths 
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 from DEVICES_3.Basler_Pylon.test_pylon import *

--- a/scripts_with_dao/dao_valid_pixel_mask_test.py
+++ b/scripts_with_dao/dao_valid_pixel_mask_test.py
@@ -19,13 +19,9 @@ from hcipy import *
 import dao
 import sys
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
+ROOT_DIR = config.root_dir
 from DEVICES_3.Basler_Pylon.test_pylon import *
 
 # Import Specific Modules
@@ -37,9 +33,9 @@ from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.create_transformation_matrices import *
 
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
+folder_calib = config.folder_calib
+folder_pyr_mask = config.folder_pyr_mask
+folder_transformation_matrices = config.folder_transformation_matrices
 
 
 #%% Accessing Devices

--- a/scripts_with_dao/slm_tests.py
+++ b/scripts_with_dao/slm_tests.py
@@ -26,21 +26,10 @@ from astropy.io import fits
 from hcipy import *
 import sys
 from pathlib import Path
+from src.config import config
 
-# Configure root paths without changing the working directory
-OPT_LAB_ROOT = Path(os.environ.get("OPT_LAB_ROOT", "/home/ristretto-dao/optlab-master"))
-PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", OPT_LAB_ROOT / "PROJECTS_3/RISTRETTO/Banc AO"))
-sys.path.append(str(OPT_LAB_ROOT))
-sys.path.append(str(PROJECT_ROOT))
-ROOT_DIR = PROJECT_ROOT
-
-# Output folders
-folder_calib = ROOT_DIR / 'outputs/Calibration_files'
-folder_pyr_mask = ROOT_DIR / 'outputs/3s_pyr_mask'
-folder_transformation_matrices = ROOT_DIR / 'outputs/Transformation_matrices'
-folder_closed_loop_tests = ROOT_DIR / 'outputs/Closed_loop_tests'
-folder_turbulence = ROOT_DIR / 'outputs/Phase_screens'
-folder_slm_tests = ROOT_DIR / 'outputs/SLM_tests'
+ROOT_DIR = config.root_dir
+folder_slm_tests = config.root_dir / 'outputs/SLM_tests'
 from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 


### PR DESCRIPTION
## Summary
- centralize path configuration in DAO scripts
- remove hardcoded `OPT_LAB_ROOT`/`PROJECT_ROOT`
- derive custom folders from `config.root_dir`

## Testing
- `python -m py_compile $(git ls-files 'scripts_with_dao/*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687860c7ffc0833081acbeafbfd6b931