### PR TITLE
Improve README for script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ export PROJECT_ROOT=/path/to/project
 These variables allow running the code from different locations without
 modifying the source files. Output directories are created under
 `PROJECT_ROOT`, which defaults to `${OPT_LAB_ROOT}/PROJECTS_3/RISTRETTO/Banc AO`.
+
+The scripts under `scripts_with_dao` rely on modules from the `src` package. Make sure the repository root is on your `PYTHONPATH`:
+
+```bash
+export PYTHONPATH=/path/to/AObench:$PYTHONPATH
+```
+
+You can also execute a script from the project root using the module syntax:
+
+```bash
+python -m scripts_with_dao.<script_name>
+```


### PR DESCRIPTION
## Summary
- explain PYTHONPATH requirement for scripts
- show module invocation option for running scripts

## Testing
- `python -m compileall -q src scripts_with_dao`

------
https://chatgpt.com/codex/tasks/task_e_68786862c7c4833096b93a8de4ce23ef