### PR TITLE
Expose deformable mirror as hardware

### DIFF
--- a/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
@@ -15,6 +15,7 @@ from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
 from hcipy import *
+from src.hardware import DeformableMirror
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_cross_correlation_3s_pyr.py
+++ b/scripts_with_dao/dao_cross_correlation_3s_pyr.py
@@ -14,6 +14,7 @@ from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
 from hcipy import *
+from src.hardware import DeformableMirror
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
@@ -12,6 +12,7 @@ from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
 from hcipy import *
+from src.hardware import DeformableMirror
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
@@ -12,6 +12,7 @@ from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
 from hcipy import *
+from src.hardware import DeformableMirror
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
@@ -20,6 +20,7 @@ from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
 from hcipy import *
+from src.hardware import DeformableMirror
 import time
 from astropy.io import fits
 import os

--- a/src/KL_basis/KL_basis_ferreira_2018_v2.py
+++ b/src/KL_basis/KL_basis_ferreira_2018_v2.py
@@ -5,6 +5,7 @@
 
 
 from hcipy import *
+from src.hardware import DeformableMirror
 import numpy as np
 import matplotlib.pyplot as plt
 get_ipython().run_line_magic('matplotlib', 'inline')

--- a/src/create_deformable_mirror.py
+++ b/src/create_deformable_mirror.py
@@ -7,6 +7,7 @@ Created on Wed Aug 21 15:05:07 2024
 
 from matplotlib import pyplot as plt
 from hcipy import *
+from src.hardware import DeformableMirror
 from PIL import Image
 import numpy as np
 import os

--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from skimage.transform import resize
 
 from src.config import config
-from src.hardware import Camera, SLM, Laser
+from src.hardware import Camera, SLM, Laser, DeformableMirror
 
 ROOT_DIR = config.root_dir
 

--- a/src/flux_filtering_mask_functions.py
+++ b/src/flux_filtering_mask_functions.py
@@ -10,6 +10,7 @@ import numpy as np
 from pypylon import pylon
 from DEVICES_3.Basler_Pylon.test_pylon import *
 from hcipy import *
+from src.hardware import DeformableMirror
 import time
 from matplotlib import pyplot as plt
 from src.dao_setup import *  # Import all variables from setup


### PR DESCRIPTION
## Summary
- add `DeformableMirror` hardware wrapper in `hardware.py`
- import the new wrapper in `dao_setup` and example scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_687869ad3e188330b3830a906204aab6