### PR TITLE
Remove DeformableMirror shared memory

### DIFF
--- a/src/hardware.py
+++ b/src/hardware.py
@@ -1,7 +1,6 @@
 import dao
 from DEVICES_3.Thorlabs.MCLS1 import mcls1
-from hcipy import DeformableMirror as _HCIPY_DM
-import numpy as np
+from hcipy import DeformableMirror
 
 class ShmWrapper:
     """Simple wrapper exposing the underlying dao.shm object."""
@@ -27,24 +26,4 @@ class Laser:
         return getattr(self.dev, attr)
 
 
-class DeformableMirror(_HCIPY_DM):
-    """Deformable mirror hardware backed by shared memory."""
 
-    def __init__(self, influence_functions, shm_path="/tmp/dm_act.im.shm"):
-        super().__init__(influence_functions)
-        self.shm = dao.shm(shm_path, np.zeros(self.num_actuators, dtype=np.float32))
-        try:
-            init_val = self.shm.get_data()
-            if init_val.size == self.num_actuators:
-                _HCIPY_DM.actuators.fset(self, init_val.ravel())
-        except Exception:
-            self.shm.set_data(self.actuators.astype(np.float32))
-
-    @property  # type: ignore[override]
-    def actuators(self):
-        return _HCIPY_DM.actuators.fget(self)
-
-    @actuators.setter
-    def actuators(self, values):
-        _HCIPY_DM.actuators.fset(self, values)
-        self.shm.set_data(np.asarray(self._actuators, dtype=np.float32))


### PR DESCRIPTION
## Summary
- rely on hcipy's `DeformableMirror` class directly
- drop the shared-memory backed subclass

## Testing
- `python -m py_compile src/hardware.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68786f926abc8330ad02f35e3de3d2d2