### PR TITLE
Fix DM attribute forwarding

### DIFF
--- a/src/hardware.py
+++ b/src/hardware.py
@@ -65,6 +65,20 @@ class DM:
         self.nmodes_dm = self.mirror.num_actuators
         self.mirror.flatten()
 
+    def __setattr__(self, attr, value):
+        local_attrs = {
+            'pupil_grid', 'pupil_mask', 'pupil_size', 'nact',
+            'dm_modes_full', 'valid_actuators_mask', 'valid_actuator_indices',
+            'nact_total', 'nact_outside', 'nact_valid', 'dm_modes',
+            'mirror', 'nmodes_dm'
+        }
+        if attr in local_attrs or 'mirror' not in self.__dict__:
+            object.__setattr__(self, attr, value)
+        elif hasattr(self.mirror, attr):
+            setattr(self.mirror, attr, value)
+        else:
+            object.__setattr__(self, attr, value)
+
     def __getattr__(self, attr):
         return getattr(self.mirror, attr)
 


### PR DESCRIPTION
## Summary
- implement `__setattr__` in `DM` so setting attributes like `actuators` updates the internal HCIPy mirror

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_68787f8db8588330bcc8ab8cd5331f36