### PR TITLE
Clean up hcipy imports

### DIFF
--- a/scripts_with_dao/comparing_oomao_hcipy_turbulence.py
+++ b/scripts_with_dao/comparing_oomao_hcipy_turbulence.py
@@ -9,7 +9,6 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
@@ -14,7 +14,6 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
@@ -14,7 +14,7 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
+from hcipy import make_gaussian_influence_functions
 from src.hardware import DeformableMirror
 import time
 from astropy.io import fits

--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -14,7 +14,6 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_cross_correlation_3s_pyr.py
+++ b/scripts_with_dao/dao_cross_correlation_3s_pyr.py
@@ -13,7 +13,7 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
+from hcipy import make_gaussian_influence_functions, make_pupil_grid
 from src.hardware import DeformableMirror
 import time
 from astropy.io import fits

--- a/scripts_with_dao/dao_implement_slm_pupil.py
+++ b/scripts_with_dao/dao_implement_slm_pupil.py
@@ -10,7 +10,6 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -13,7 +13,6 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
@@ -11,7 +11,7 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
+from hcipy import make_gaussian_influence_functions, make_pupil_grid
 from src.hardware import DeformableMirror
 import time
 from astropy.io import fits

--- a/scripts_with_dao/dao_push-pull_calibration_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_kl_3s_pyr.py
@@ -14,7 +14,6 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
@@ -11,7 +11,7 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
+from hcipy import make_gaussian_influence_functions
 from src.hardware import DeformableMirror
 import time
 from astropy.io import fits

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
@@ -19,7 +19,7 @@ from pypylon import pylon
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
+from hcipy import make_gaussian_influence_functions
 from src.hardware import DeformableMirror
 import time
 from astropy.io import fits

--- a/scripts_with_dao/dao_testing_DM_tip_tilt.py
+++ b/scripts_with_dao/dao_testing_DM_tip_tilt.py
@@ -9,7 +9,6 @@ Created on Thu Jul 17 01:55:52 2025
 from matplotlib import pyplot as plt
 from PIL import Image
 import numpy as np
-from hcipy import *
 import time
 from astropy.io import fits
 import os

--- a/scripts_with_dao/dao_transformation_matrices.py
+++ b/scripts_with_dao/dao_transformation_matrices.py
@@ -15,7 +15,6 @@ import cv2
 from matplotlib import pyplot as plt
 from PIL import Image
 from astropy.io import fits
-from hcipy import *
 import dao
 import sys
 from pathlib import Path

--- a/scripts_with_dao/dao_valid_pixel_mask_test.py
+++ b/scripts_with_dao/dao_valid_pixel_mask_test.py
@@ -15,7 +15,6 @@ import cv2
 from matplotlib import pyplot as plt
 from PIL import Image
 from astropy.io import fits
-from hcipy import *
 import dao
 import sys
 from pathlib import Path

--- a/scripts_with_dao/slm_tests.py
+++ b/scripts_with_dao/slm_tests.py
@@ -23,7 +23,6 @@ import cv2
 from matplotlib import pyplot as plt
 from PIL import Image
 from astropy.io import fits
-from hcipy import *
 import sys
 from pathlib import Path
 from src.config import config

--- a/src/KL_basis/KL_basis_ferreira_2018_v2.py
+++ b/src/KL_basis/KL_basis_ferreira_2018_v2.py
@@ -4,7 +4,12 @@
 # In[2]:
 
 
-from hcipy import *
+from hcipy import (
+    evaluate_supersampled,
+    make_gaussian_influence_functions,
+    make_obstructed_circular_aperture,
+    make_pupil_grid,
+)
 from src.hardware import DeformableMirror
 import numpy as np
 import matplotlib.pyplot as plt

--- a/src/ao_loop_functions.py
+++ b/src/ao_loop_functions.py
@@ -13,7 +13,6 @@ from tqdm import tqdm
 from PIL import Image
 from matplotlib.colors import LogNorm
 from src.utils import *
-from hcipy import *
 from DEVICES_3.Basler_Pylon.test_pylon import *
 from collections import deque
 from src.dao_setup import *  # Import all variables from setup

--- a/src/circular_pupil_functions.py
+++ b/src/circular_pupil_functions.py
@@ -7,7 +7,6 @@ Created on Wed Aug  7 16:49:32 2024
 
 from matplotlib import pyplot as plt
 import numpy as np
-from hcipy import *
 from src.tilt_functions import *
 
 def create_slm_circular_pupil(tilt_amp_outer, tilt_amp_inner, pupil_size, pupil_mask, slm):

--- a/src/create_deformable_mirror.py
+++ b/src/create_deformable_mirror.py
@@ -6,7 +6,7 @@ Created on Wed Aug 21 15:05:07 2024
 """
 
 from matplotlib import pyplot as plt
-from hcipy import *
+from hcipy import make_gaussian_influence_functions
 from src.hardware import DeformableMirror
 from PIL import Image
 import numpy as np

--- a/src/create_phase_screens.py
+++ b/src/create_phase_screens.py
@@ -6,7 +6,12 @@ Created on Mon Nov 4 15:22:51 2024
 """
 
 from matplotlib import pyplot as plt
-from hcipy import *
+from hcipy import (
+    Cn_squared_from_fried_parameter,
+    InfiniteAtmosphericLayer,
+    make_pupil_grid,
+    seeing_to_fried_parameter,
+)
 import numpy as np
 import os
 import sys

--- a/src/create_turbulence.py
+++ b/src/create_turbulence.py
@@ -10,7 +10,14 @@ import os
 import time
 from astropy.io import fits
 from matplotlib import pyplot as plt
-from hcipy import *
+from hcipy import (
+    Cn_squared_from_fried_parameter,
+    InfiniteAtmosphericLayer,
+    evaluate_supersampled,
+    make_obstructed_circular_aperture,
+    make_pupil_grid,
+    seeing_to_fried_parameter,
+)
 
 #%% Setup pupil on the SLM
 

--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -7,7 +7,12 @@ Created on Mon Feb 17 13:56:42 2025
 """
 
 # Import Libraries
-from hcipy import *
+from hcipy import (
+    evaluate_supersampled,
+    make_obstructed_circular_aperture,
+    make_pupil_grid,
+    make_zernike_basis,
+)
 from matplotlib.colors import LogNorm
 import gc
 from tqdm import tqdm

--- a/src/flux_filtering_mask_functions.py
+++ b/src/flux_filtering_mask_functions.py
@@ -9,7 +9,6 @@ Created on Mon Feb 17 16:19:48 2025
 import numpy as np
 from pypylon import pylon
 from DEVICES_3.Basler_Pylon.test_pylon import *
-from hcipy import *
 import time
 from matplotlib import pyplot as plt
 from src.dao_setup import *  # Import all variables from setup

--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -4,7 +4,6 @@ from matplotlib import pyplot as plt
 import numpy as np
 import os
 import time
-from hcipy import *
 from skopt import gp_minimize
 from DEVICES_3.Basler_Pylon.test_pylon import *
 import sys

--- a/src/transformation_matrices_functions.py
+++ b/src/transformation_matrices_functions.py
@@ -10,7 +10,7 @@ import scipy.linalg
 import os
 import matplotlib.pyplot as plt
 from astropy.io import fits
-from hcipy import *
+from hcipy import make_zernike_basis
 from src.kl_basis_eigenmodes_functions import *
 from src.utils import *
 import sys


### PR DESCRIPTION
## Summary
- remove unused wildcard imports from hcipy
- keep specific hcipy functions where needed

## Testing
- `pyflakes src/*.py scripts_with_dao/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687885d27a988330be4c7aeaa1f41d24