### PR TITLE
Refactor dao_setup initialization

### DIFF
--- a/scripts_with_dao/AO_bench_STARTUP.txt
+++ b/scripts_with_dao/AO_bench_STARTUP.txt
@@ -56,7 +56,8 @@ System Setup Procedure
 -------------------
 - Open scripts_with_dao/dao_calibrations_file.py
 - Run the following steps:
-  - Import libraries (especially: from src.dao_setup import *)
+  - Import libraries (especially: from src.dao_setup import init_setup
+setup = init_setup())
   - Take a bias frame
   - Turn on the laser
   - Create and set a circular pupil on the SLM

--- a/scripts_with_dao/comparing_oomao_hcipy_turbulence.py
+++ b/scripts_with_dao/comparing_oomao_hcipy_turbulence.py
@@ -29,7 +29,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *
 from src.ao_loop import *

--- a/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
@@ -27,7 +27,8 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.utils import *
 from src.circular_pupil_functions import *
 from src.flux_filtering_mask_functions import *

--- a/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
@@ -36,7 +36,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *
 from src.ao_loop import *

--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -28,7 +28,8 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.utils import *
 from src.circular_pupil_functions import *
 from src.flux_filtering_mask_functions import *

--- a/scripts_with_dao/dao_cross_correlation_3s_pyr.py
+++ b/scripts_with_dao/dao_cross_correlation_3s_pyr.py
@@ -35,7 +35,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 
 #%% Accessing Devices

--- a/scripts_with_dao/dao_implement_slm_pupil.py
+++ b/scripts_with_dao/dao_implement_slm_pupil.py
@@ -21,7 +21,8 @@ from src.config import config
 ROOT_DIR = config.root_dir
 
 # Import specific modules
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 
 #%%
 

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -28,7 +28,8 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.utils import *
 from src.circular_pupil_functions import *
 from src.flux_filtering_mask_functions import *

--- a/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
@@ -32,7 +32,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 
 #%% Accessing Devices
 

--- a/scripts_with_dao/dao_push-pull_calibration_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_kl_3s_pyr.py
@@ -32,7 +32,8 @@ from src.create_circular_pupil import *
 from src.tilt import *
 from src.utils import *
 from src.calibration_functions import *
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *
 from src.ao_loop import *

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
@@ -32,7 +32,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *
 

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
@@ -40,7 +40,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *
 

--- a/scripts_with_dao/dao_test_DM_units.py
+++ b/scripts_with_dao/dao_test_DM_units.py
@@ -8,7 +8,8 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.utils import *
 
 # Flatten the DM surface and set actuator values

--- a/scripts_with_dao/dao_testing_DM_tip_tilt.py
+++ b/scripts_with_dao/dao_testing_DM_tip_tilt.py
@@ -22,7 +22,8 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.utils import *
 from src.circular_pupil_functions import *
 from src.flux_filtering_mask_functions import *

--- a/scripts_with_dao/dao_transformation_matrices.py
+++ b/scripts_with_dao/dao_transformation_matrices.py
@@ -26,7 +26,8 @@ ROOT_DIR = config.root_dir
 from DEVICES_3.Basler_Pylon.test_pylon import *
 
 #import src.dao_setup as dao_setup  # Import the setup file
-from src.dao_setup import *
+from src.dao_setup import init_setup
+setup = init_setup()
 from src.create_circular_pupil import *
 from src.tilt import *
 from src.utils import *

--- a/scripts_with_dao/dao_valid_pixel_mask_test.py
+++ b/scripts_with_dao/dao_valid_pixel_mask_test.py
@@ -24,7 +24,8 @@ ROOT_DIR = config.root_dir
 from DEVICES_3.Basler_Pylon.test_pylon import *
 
 # Import Specific Modules
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.create_circular_pupil import *
 from src.tilt import *
 from src.utils import *

--- a/scripts_with_dao/slm_tests.py
+++ b/scripts_with_dao/slm_tests.py
@@ -33,7 +33,8 @@ from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
 
 # Import Specific Modules
-from src.dao_setup import *  # Import all variables from setup
+from src.dao_setup import init_setup
+setup = init_setup()  # Import all variables from setup
 from src.create_circular_pupil import *
 from src.tilt import *
 from src.utils import *

--- a/src/ao_loop_functions.py
+++ b/src/ao_loop_functions.py
@@ -15,8 +15,9 @@ from matplotlib.colors import LogNorm
 from src.utils import *
 from DEVICES_3.Basler_Pylon.test_pylon import *
 from collections import deque
-from src.dao_setup import *  # Import all variables from setup
-import src.dao_setup as dao_setup
+from src.dao_setup import init_setup
+
+setup = init_setup()
 from src.create_shared_memories import *
 
 
@@ -58,25 +59,25 @@ def closed_loop_test(num_iterations, gain, leakage, delay, data_phase_screen, an
     - aim_name: Name for the saved animation file
     - anim_title: Title of the animation
     """
-    from src.dao_setup import wait_time  # lazy import to avoid circular dependency
-    
+    wait_time = setup.wait_time
+
     # Load hardware and configuration parameters
-    deformable_mirror = kwargs.get("deformable_mirror", dao_setup.deformable_mirror)
-    slm = kwargs.get("slm", dao_setup.slm)
-    camera_wfs = kwargs.get("camera_wfs", dao_setup.camera_wfs)
-    camera_fp = kwargs.get("camera_fp", dao_setup.camera_fp)
-    npix_small_pupil_grid = kwargs.get("npix_small_pupil_grid", dao_setup.npix_small_pupil_grid)
-    data_pupil = kwargs.get("data_pupil", dao_setup.data_pupil)
-    data_pupil_outer = kwargs.get("data_pupil_outer", dao_setup.data_pupil_outer)
-    data_pupil_inner = kwargs.get("data_pupil_inner", dao_setup.data_pupil_inner)
-    pupil_mask = kwargs.get("pupil_mask", dao_setup.pupil_mask)
-    small_pupil_mask = kwargs.get("small_pupil_mask", dao_setup.small_pupil_mask)
+    deformable_mirror = kwargs.get("deformable_mirror", setup.deformable_mirror)
+    slm = kwargs.get("slm", setup.slm)
+    camera_wfs = kwargs.get("camera_wfs", setup.camera_wfs)
+    camera_fp = kwargs.get("camera_fp", setup.camera_fp)
+    npix_small_pupil_grid = kwargs.get("npix_small_pupil_grid", setup.npix_small_pupil_grid)
+    data_pupil = kwargs.get("data_pupil", setup.pupil_setup.data_pupil)
+    data_pupil_outer = kwargs.get("data_pupil_outer", setup.pupil_setup.data_pupil_outer)
+    data_pupil_inner = kwargs.get("data_pupil_inner", setup.pupil_setup.data_pupil_inner)
+    pupil_mask = kwargs.get("pupil_mask", setup.pupil_setup.pupil_mask)
+    small_pupil_mask = kwargs.get("small_pupil_mask", setup.pupil_setup.small_pupil_mask)
     
     # Load the folder
-    folder_gui = kwargs.get("folder_gui", dao_setup.folder_gui)
+    folder_gui = kwargs.get("folder_gui", setup.folder_gui)
     
     # Display Pupil Data on SLM
-    data_slm = compute_data_slm()
+    data_slm = compute_data_slm(setup=setup.pupil_setup)
     slm.set_data(data_slm)
     time.sleep(wait_time)  # Wait for stabilization of SLM
         
@@ -211,7 +212,7 @@ def closed_loop_test(num_iterations, gain, leakage, delay, data_phase_screen, an
         residual_modes_shm.set_data(residual_modes) # setting shared memory
 
         # Compute and  set SLM command
-        data_slm = compute_data_slm(data_dm=data_dm, data_phase_screen=phase_slice)
+        data_slm = compute_data_slm(data_dm=data_dm, data_phase_screen=phase_slice, setup=setup.pupil_setup)
         slm.set_data(data_slm) # setting shared memory
         time.sleep(wait_time)
 

--- a/src/calibration_functions.py
+++ b/src/calibration_functions.py
@@ -4,8 +4,9 @@ import dao
 import matplotlib.pyplot as plt
 from datetime import datetime
 from src.utils import *
-from src.dao_setup import *  # Import all variables from setup
-import src.dao_setup as dao_setup
+from src.dao_setup import init_setup
+
+setup = init_setup()
 
 
 def perform_push_pull_calibration_with_phase_basis(basis, phase_amp, ref_image, mask,
@@ -33,15 +34,15 @@ def perform_push_pull_calibration_with_phase_basis(basis, phase_amp, ref_image, 
     Returns:
     - pull_images, push_images, push_pull_images
     """
-    from src.dao_setup import wait_time  # lazy import to avoid circular dependency
+    wait_time = setup.wait_time
 
-    # Load devices and data from kwargs or fallback to dao_setup
-    camera = kwargs.get("camera", dao_setup.camera_wfs)
-    slm = kwargs.get("slm", dao_setup.slm)
-    pupil_mask = kwargs.get("pupil_mask", dao_setup.pupil_mask)
-    small_pupil_mask = kwargs.get("small_pupil_mask", dao_setup.small_pupil_mask)
-    deformable_mirror = kwargs.get("deformable_mirror", dao_setup.deformable_mirror)
-    nact = kwargs.get("nact", dao_setup.nact)
+    # Load devices and data from kwargs or fallback to setup
+    camera = kwargs.get("camera", setup.camera_wfs)
+    slm = kwargs.get("slm", setup.slm)
+    pupil_mask = kwargs.get("pupil_mask", setup.pupil_setup.pupil_mask)
+    small_pupil_mask = kwargs.get("small_pupil_mask", setup.pupil_setup.small_pupil_mask)
+    deformable_mirror = kwargs.get("deformable_mirror", setup.deformable_mirror)
+    nact = kwargs.get("nact", setup.nact)
 
     # Set dimensions equal to img_size
     height, width = ref_image.shape
@@ -113,7 +114,7 @@ def perform_push_pull_calibration_with_phase_basis(basis, phase_amp, ref_image, 
 
                 # Add and wrap data within the pupil mask
                 t4 = time.time()
-                data_slm = compute_data_slm(data_dm=data_dm)
+                data_slm = compute_data_slm(data_dm=data_dm, setup=setup.pupil_setup)
                 slm.set_data(data_slm)
                 time.sleep(wait_time)
                 t7 = time.time()
@@ -267,9 +268,9 @@ def create_response_matrix(
         Flattened 2D response matrix for all modes.
     """
     
-    pupil_size = kwargs.get("pupil_size", dao_setup.pupil_size)
-    nact = kwargs.get("nact", dao_setup.nact)
-    folder_calib = kwargs.get("folder_calib", dao_setup.folder_calib)
+    pupil_size = kwargs.get("pupil_size", setup.pupil_size)
+    nact = kwargs.get("nact", setup.nact)
+    folder_calib = kwargs.get("folder_calib", setup.folder_calib)
 
     # Run push-pull calibration
     n_runs = max(1, int(calibration_repetitions))

--- a/src/create_shared_memories.py
+++ b/src/create_shared_memories.py
@@ -1,27 +1,25 @@
 import dao
 import numpy as np
 import os
-import sys
-from pathlib import Path
 
 from src.config import config
 
 ROOT_DIR = config.root_dir
 
 # Explicit imports from dao_setup
-from src.dao_setup import (npix_small_pupil_grid, dataHeight, dataWidth, 
-                           img_size_wfs_cam, img_size_fp_cam, 
-                            nmodes_KL, nact, nmodes_dm)
+from src.dao_setup import init_setup
+
+setup = init_setup()
 
 # Pupil / Grids
-small_pupil_mask_shm = dao.shm('/tmp/small_pupil_mask.im.shm', np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32))
-pupil_mask_shm       = dao.shm('/tmp/pupil_mask.im.shm',       np.zeros((dataHeight, dataWidth), dtype=np.float32))
+small_pupil_mask_shm = dao.shm('/tmp/small_pupil_mask.im.shm', np.zeros((setup.npix_small_pupil_grid, setup.npix_small_pupil_grid), dtype=np.float32))
+pupil_mask_shm       = dao.shm('/tmp/pupil_mask.im.shm',       np.zeros((setup.dataHeight, setup.dataWidth), dtype=np.float32))
 
 # WFS
-slopes_img_shm       = dao.shm('/tmp/slopes_img.im.shm',       np.zeros((img_size_wfs_cam, img_size_wfs_cam), dtype=np.uint32))
+slopes_img_shm       = dao.shm('/tmp/slopes_img.im.shm',       np.zeros((setup.img_size_wfs_cam, setup.img_size_wfs_cam), dtype=np.uint32))
 
 # Deformable Mirror
-dm_act_shm           = dao.shm('/tmp/dm_act.im.shm',           np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32))
+dm_act_shm           = dao.shm('/tmp/dm_act.im.shm',           np.zeros((setup.npix_small_pupil_grid, setup.npix_small_pupil_grid), dtype=np.float32))
 
 # SLM
 # slm_shm             = dao.shm('/tmp/slm.im.shm',              np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32))
@@ -29,9 +27,9 @@ dm_act_shm           = dao.shm('/tmp/dm_act.im.shm',           np.zeros((npix_sm
 # Transformation Matrices
 # Act2Phs_shm        = dao.shm('/tmp/Act2Phs.im.shm',          np.zeros((nact**2, npix_small_pupil_grid**2), dtype=np.float64))
 # Phs2Act_shm        = dao.shm('/tmp/Phs2Act.im.shm',          np.zeros((npix_small_pupil_grid**2, nact**2), dtype=np.float64))
-KL2Act_shm           = dao.shm('/tmp/KL2Act.im.shm',           np.zeros((nmodes_KL, nact**2), dtype=np.float64))
+KL2Act_shm           = dao.shm('/tmp/KL2Act.im.shm',           np.zeros((setup.nmodes_KL, setup.nact**2), dtype=np.float64))
 # Act2KL_shm         = dao.shm('/tmp/Act2KL.im.shm',           np.zeros((nact**2, nmodes_KL), dtype=np.float64))
-KL2Phs_shm           = dao.shm('/tmp/KL2Phs.im.shm',           np.zeros((nmodes_KL, npix_small_pupil_grid**2), dtype=np.float64))
+KL2Phs_shm           = dao.shm('/tmp/KL2Phs.im.shm',           np.zeros((setup.nmodes_KL, setup.npix_small_pupil_grid**2), dtype=np.float64))
 # Phs2KL_shm         = dao.shm('/tmp/Phs2KL.im.shm',           np.zeros((npix_small_pupil_grid**2, nmodes_KL), dtype=np.float64))
 
 # Zernike 
@@ -62,12 +60,12 @@ leakage_shm                  = dao.shm('/tmp/leakage.im.shm',                 np
 num_iterations_shm           = dao.shm('/tmp/num_iterations.im.shm',          np.zeros((1, 1), dtype=np.uint32))
 
 # AO loop plots
-slopes_image_shm             = dao.shm('/tmp/slopes_image.im.shm',            np.zeros((img_size_wfs_cam, img_size_wfs_cam), dtype=np.float64))
-phase_screen_shm             = dao.shm('/tmp/phase_screen.im.shm',            np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32))
-dm_phase_shm                 = dao.shm('/tmp/dm_phase.im.shm',                np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32))
-phase_residuals_shm          = dao.shm('/tmp/phase_residuals.im.shm',         np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32))
-normalized_psf_shm           = dao.shm('/tmp/normalized_psf.im.shm',          np.zeros((img_size_fp_cam, img_size_fp_cam), dtype=np.float64))
-commands_shm                 = dao.shm('/tmp/commands.im.shm',                np.zeros((nmodes_dm, 1), dtype=np.float32))
-residual_modes_shm           = dao.shm('/tmp/residual_modes.im.shm',          np.zeros((nmodes_KL, 1), dtype=np.float32))
-computed_modes_shm           = dao.shm('/tmp/computed_modes.im.shm',          np.zeros((nmodes_KL, 1), dtype=np.float32))
-dm_kl_modes_shm              = dao.shm('/tmp/dm_kl_modes.im.shm',             np.zeros((nmodes_KL, 1), dtype=np.float32))
+slopes_image_shm             = dao.shm('/tmp/slopes_image.im.shm',            np.zeros((setup.img_size_wfs_cam, setup.img_size_wfs_cam), dtype=np.float64))
+phase_screen_shm             = dao.shm('/tmp/phase_screen.im.shm',            np.zeros((setup.npix_small_pupil_grid, setup.npix_small_pupil_grid), dtype=np.float32))
+dm_phase_shm                 = dao.shm('/tmp/dm_phase.im.shm',                np.zeros((setup.npix_small_pupil_grid, setup.npix_small_pupil_grid), dtype=np.float32))
+phase_residuals_shm          = dao.shm('/tmp/phase_residuals.im.shm',         np.zeros((setup.npix_small_pupil_grid, setup.npix_small_pupil_grid), dtype=np.float32))
+normalized_psf_shm           = dao.shm('/tmp/normalized_psf.im.shm',          np.zeros((setup.img_size_fp_cam, setup.img_size_fp_cam), dtype=np.float64))
+commands_shm                 = dao.shm('/tmp/commands.im.shm',                np.zeros((setup.nmodes_dm, 1), dtype=np.float32))
+residual_modes_shm           = dao.shm('/tmp/residual_modes.im.shm',          np.zeros((setup.nmodes_KL, 1), dtype=np.float32))
+computed_modes_shm           = dao.shm('/tmp/computed_modes.im.shm',          np.zeros((setup.nmodes_KL, 1), dtype=np.float32))
+dm_kl_modes_shm              = dao.shm('/tmp/dm_kl_modes.im.shm',             np.zeros((setup.nmodes_KL, 1), dtype=np.float32))

--- a/src/create_transformation_matrices.py
+++ b/src/create_transformation_matrices.py
@@ -20,17 +20,36 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import *  # Import all variables from setup
-from src.transformation_matrices_functions import * 
+from src.dao_setup import init_setup
+import src.dao_setup as dao_setup
+from src.transformation_matrices_functions import *
 from src.create_shared_memories import *
 
-Act2Phs, Phs2Act = compute_Act2Phs(nact, npix_small_pupil_grid, dm_modes_full, folder_transformation_matrices, verbose=True)
+setup = init_setup()
+
+Act2Phs, Phs2Act = compute_Act2Phs(
+    setup.nact,
+    setup.npix_small_pupil_grid,
+    dao_setup.dm_modes_full,
+    setup.folder_transformation_matrices,
+    verbose=True,
+)
 
 # Create KL modes
-nmodes_kl = nact_valid
+nmodes_kl = dao_setup.nact_valid
 # Act2KL, KL2Act = compute_KL2Act(nact, npix_small_pupil_grid, nmodes_kl, dm_modes_full, small_pupil_mask, folder_transformation_matrices, verbose=True)
 # KL2Phs, Phs2KL = compute_KL2Phs(nact, npix_small_pupil_grid, nmodes_kl, Act2Phs, Phs2Act, KL2Act, Act2KL, folder_transformation_matrices, verbose=True)
-KL2Act, KL2Phs = compute_KL(nact, npix_small_pupil_grid, nmodes_kl, dm_modes_full, Act2Phs, Phs2Act, small_pupil_mask, folder_transformation_matrices, verbose=False)
+KL2Act, KL2Phs = compute_KL(
+    setup.nact,
+    setup.npix_small_pupil_grid,
+    nmodes_kl,
+    dao_setup.dm_modes_full,
+    Act2Phs,
+    Phs2Act,
+    dao_setup.small_pupil_mask,
+    setup.folder_transformation_matrices,
+    verbose=False,
+)
 
 
 # set shared memories
@@ -45,7 +64,7 @@ fig, axes = plt.subplots(2, 5, figsize=(15, 6))
 axes_flat = axes.flatten()
 
 for i, mode in enumerate(range(10)):
-    im = axes_flat[i].imshow(KL2Act[mode].reshape(nact, nact), cmap='viridis')
+    im = axes_flat[i].imshow(KL2Act[mode].reshape(setup.nact, setup.nact), cmap='viridis')
     axes_flat[i].set_title(f' KL2Act {mode}')
     axes_flat[i].axis('off')
     fig.colorbar(im, ax=axes_flat[i], fraction=0.03, pad=0.04)
@@ -59,7 +78,7 @@ fig, axes = plt.subplots(2, 5, figsize=(15, 6))
 axes_flat = axes.flatten()
 
 for i, mode in enumerate(range(10)):
-    im = axes_flat[i].imshow(KL2Phs[mode].reshape(npix_small_pupil_grid, npix_small_pupil_grid), cmap='viridis')
+    im = axes_flat[i].imshow(KL2Phs[mode].reshape(setup.npix_small_pupil_grid, setup.npix_small_pupil_grid), cmap='viridis')
     axes_flat[i].set_title(f' KL2Phs {mode}')
     axes_flat[i].axis('off')
     fig.colorbar(im, ax=axes_flat[i], fraction=0.03, pad=0.04)
@@ -76,7 +95,11 @@ fig, axes = plt.subplots(2, 5, figsize=(15, 6))
 axes_flat = axes.flatten()
 
 for i, mode in enumerate(range(10)):
-    im = axes_flat[i].imshow(KL2Phs_new[mode].reshape(npix_small_pupil_grid, npix_small_pupil_grid)*small_pupil_mask, cmap='viridis')
+    im = axes_flat[i].imshow(
+        KL2Phs_new[mode].reshape(setup.npix_small_pupil_grid, setup.npix_small_pupil_grid)
+        * dao_setup.small_pupil_mask,
+        cmap='viridis',
+    )
     axes_flat[i].set_title(f' KL2Phs new {mode}')
     axes_flat[i].axis('off')
     fig.colorbar(im, ax=axes_flat[i], fraction=0.03, pad=0.04)
@@ -92,7 +115,7 @@ fig, axes = plt.subplots(2, 5, figsize=(15, 6))
 axes_flat = axes.flatten()
 
 for i, mode in enumerate(range(10)):
-    im = axes_flat[i].imshow(KL2Act_new[mode].reshape(nact, nact), cmap='viridis')
+    im = axes_flat[i].imshow(KL2Act_new[mode].reshape(setup.nact, setup.nact), cmap='viridis')
     axes_flat[i].set_title(f' KL2Act new {mode}')
     axes_flat[i].axis('off')
     fig.colorbar(im, ax=axes_flat[i], fraction=0.03, pad=0.04)

--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -15,13 +15,13 @@ from src.config import config
 
 ROOT_DIR = config.root_dir
 
-from src.dao_setup import (
-    wait_time,
-    pupil_setup,
-    camera_wfs,
-    slm,
-    ROOT_DIR,
-)
+from src.dao_setup import init_setup, ROOT_DIR
+
+setup = init_setup()
+wait_time = setup.wait_time
+pupil_setup = setup.pupil_setup
+camera_wfs = setup.camera_wfs
+slm = setup.slm
 
 
 # Access the SLM and cameras

--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -1,14 +1,14 @@
 import time
 import numpy as np
 
-from src.dao_setup import (
-    wait_time,
-    pupil_setup,
-    camera_fp,
-    camera_wfs,
-    slm,
-    ROOT_DIR,
-)
+from src.dao_setup import init_setup, ROOT_DIR
+
+setup = init_setup()
+wait_time = setup.wait_time
+pupil_setup = setup.pupil_setup
+camera_fp = setup.camera_fp
+camera_wfs = setup.camera_wfs
+slm = setup.slm
 from pathlib import Path
 import re
 

--- a/src/tilt_functions.py
+++ b/src/tilt_functions.py
@@ -9,8 +9,7 @@ Created on Fri Aug 16 16:40:08 2024
 
 import numpy as np
 from matplotlib import pyplot as plt
-from src.dao_setup import *  # Import all variables from setup
-#import src.dao_setup as dao_setup
+
 
 
 def apply_intensity_tilt(image, pupil_radius, tilt_angle):

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,8 +10,13 @@ import numpy as np
 from astropy.io import fits
 from scipy.ndimage import center_of_mass
 from scipy.interpolate import interp2d
-from src.dao_setup import *  # Import all variables from setup
-import src.dao_setup as dao_setup
+
+DEFAULT_SETUP = None
+
+def set_default_setup(setup):
+    """Register a default setup used when none is provided."""
+    global DEFAULT_SETUP
+    DEFAULT_SETUP = setup
 
 
 # Add and wrap data within the pupil mask
@@ -35,15 +40,14 @@ def compute_data_slm(data_dm=0, data_phase_screen=0, setup=None, **kwargs):
     """
     
     if setup is None:
-        data_pupil_inner = kwargs.get("data_pupil_inner", dao_setup.data_pupil_inner_new)
-        data_pupil_outer = kwargs.get("data_pupil_outer", dao_setup.data_pupil_outer)
-        pupil_mask = kwargs.get("pupil_mask", dao_setup.pupil_mask)
-        small_pupil_mask = kwargs.get("small_pupil_mask", dao_setup.small_pupil_mask)
-    else:
-        data_pupil_inner = kwargs.get("data_pupil_inner", setup.data_pupil_inner_new)
-        data_pupil_outer = kwargs.get("data_pupil_outer", setup.data_pupil_outer)
-        pupil_mask = kwargs.get("pupil_mask", setup.pupil_mask)
-        small_pupil_mask = kwargs.get("small_pupil_mask", setup.small_pupil_mask)
+        if DEFAULT_SETUP is None:
+            raise ValueError("No setup provided and no default registered.")
+        setup = DEFAULT_SETUP
+
+    data_pupil_inner = kwargs.get("data_pupil_inner", setup.data_pupil_inner_new)
+    data_pupil_outer = kwargs.get("data_pupil_outer", setup.data_pupil_outer)
+    pupil_mask = kwargs.get("pupil_mask", setup.pupil_mask)
+    small_pupil_mask = kwargs.get("small_pupil_mask", setup.small_pupil_mask)
 
     data_slm = data_pupil_outer.copy()
     data_inner = (((data_pupil_inner + data_dm + data_phase_screen) * 256) % 256)


### PR DESCRIPTION
## Summary
- add a concise module docstring to `dao_setup`
- remove unused imports and star imports
- expose new `DAOSetup` dataclass and `init_setup`
- avoid circular imports by updating `utils`
- update modules and scripts to create a setup object

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68788f74d15c833093bd8febb0ed6ecb