### PR TITLE
Fix PupilSetup initialization

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -226,10 +226,10 @@ class PupilSetup:
         self.data_pupil_outer = data_pupil_outer
         self.data_pupil_inner = data_pupil_inner
         self.data_pupil_inner_new = data_pupil_inner_new
-        self.data_slm = compute_data_slm(setup=self)
         # Store masks for later use when recomputing the pupil
         self.pupil_mask = pupil_mask
         self.small_pupil_mask = small_pupil_mask
+        self.data_slm = compute_data_slm(setup=self)
 
     def _recompute_dm(self):
         """(Re)compute DM contribution and assemble the pupil."""


### PR DESCRIPTION
## Summary
- fix a crash during initialization of `PupilSetup`

## Testing
- `python -m py_compile src/dao_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6878980c509c83309e9f9bb95f7714ee