### PR TITLE
Fix missing attributes in DAOSetup

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -303,6 +303,14 @@ class DAOSetup:
     folder_closed_loop_tests: str
     folder_turbulence: str
     folder_gui: str
+    img_size_wfs_cam: int
+    img_size_fp_cam: int
+    nact: int
+    nact_valid: int
+    nact_total: int
+    nmodes_dm: int
+    nmodes_KL: int
+    nmodes_Znk: int
 
 
 def init_setup() -> DAOSetup:
@@ -324,6 +332,14 @@ def init_setup() -> DAOSetup:
         folder_closed_loop_tests=str(folder_closed_loop_tests),
         folder_turbulence=str(folder_turbulence),
         folder_gui=str(folder_gui),
+        img_size_wfs_cam=img_size_wfs_cam,
+        img_size_fp_cam=img_size_fp_cam,
+        nact=nact,
+        nact_valid=nact_valid,
+        nact_total=nact_total,
+        nmodes_dm=nmodes_dm,
+        nmodes_KL=nmodes_KL,
+        nmodes_Znk=nmodes_Znk,
     )
 
 


### PR DESCRIPTION
## Summary
- extend `DAOSetup` dataclass with camera sizes and DM/loop metadata
- return the new attributes from `init_setup`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_687899121344833087cd8b770250869b