### PR TITLE
Add pupil mask attributes to DAOSetup

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -314,6 +314,8 @@ class DAOSetup:
     nmodes_dm: int
     nmodes_KL: int
     nmodes_Znk: int
+    small_pupil_mask: np.ndarray
+    pupil_mask: np.ndarray
 
 
 def init_setup() -> DAOSetup:
@@ -346,6 +348,8 @@ def init_setup() -> DAOSetup:
         nmodes_dm=nmodes_dm,
         nmodes_KL=nmodes_KL,
         nmodes_Znk=nmodes_Znk,
+        small_pupil_mask=small_pupil_mask,
+        pupil_mask=pupil_mask,
     )
 
 


### PR DESCRIPTION
## Summary
- extend `DAOSetup` dataclass with `small_pupil_mask` and `pupil_mask`
- populate the new fields in `init_setup`

## Testing
- `python -m py_compile src/dao_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6879004172d88330a9754a59d810b7b4