### PR TITLE
Create common imports helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ You can also execute a script from the project root using the module syntax:
 ```bash
 python -m scripts_with_dao.<script_name>
 ```
+
+## Common Imports
+
+Most scripts share a long list of imports. These have been grouped into
+`src/common_imports.py` so they can be included with a single statement:
+
+```python
+from src.common_imports import *
+```
+
+This initializes the standard hardware setup and exposes all commonly used
+helper functions.

--- a/src/common_imports.py
+++ b/src/common_imports.py
@@ -1,0 +1,47 @@
+"""Common imports for AO bench scripts.
+
+This module centralizes frequently used imports and provides a ready-to-use
+``setup`` object. Scripts under ``scripts_with_dao`` can simply do::
+
+    from src.common_imports import *
+
+This keeps each script short and ensures consistent initialization.
+"""
+
+# Standard library
+import os
+import sys
+import time
+from pathlib import Path
+
+# Third-party libraries
+import numpy as np
+import scipy
+from astropy.io import fits
+from matplotlib import pyplot as plt
+from matplotlib.colors import LogNorm
+import matplotlib.animation as animation
+from PIL import Image
+from tqdm import tqdm
+from pypylon import pylon
+
+# AO bench modules
+from src.config import config
+from src.dao_setup import init_setup
+from src.utils import *
+from src.circular_pupil_functions import *
+from src.flux_filtering_mask_functions import *
+from src.tilt_functions import *
+from src.calibration_functions import *
+from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenModes_notsquarepupil
+from src.transformation_matrices_functions import *
+from src.psf_centring_algorithm_functions import *
+from src.create_shared_memories import *
+from src.scan_modes_functions import scan_othermode_amplitudes
+from src.ao_loop_functions import *
+
+# Initialize the default setup for convenience
+setup = init_setup()
+
+# Export all loaded names except for private ones
+__all__ = [name for name in globals() if not name.startswith('_')]


### PR DESCRIPTION
## Summary
- add `src/common_imports.py` with shared imports and setup
- document the helper module in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68798fc0dca88330a3fed62886fa6607