### PR TITLE
Clean up unused imports

### DIFF
--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -6,22 +6,16 @@ Created on Mon Feb 17 14:49:20 2025
 @author: laboptic
 """
 
-# Import Libraries
-from matplotlib.colors import LogNorm
-import gc
-from tqdm import tqdm
-from pypylon import pylon
-from matplotlib import pyplot as plt
-from PIL import Image
-import numpy as np
-import time
-from astropy.io import fits
+# Standard library
 import os
-import sys
-import scipy
-import matplotlib.animation as animation
-from pathlib import Path
+import time
 from datetime import datetime
+
+# Third-party libraries
+import numpy as np
+from astropy.io import fits
+from matplotlib import pyplot as plt
+
 from src.config import config
 
 ROOT_DIR = config.root_dir


### PR DESCRIPTION
## Summary
- drop unused libraries from `dao_calibrations_file.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_6879937c2e1c8330b713e17392306e9f