### PR TITLE
Clean up imports in DAO scripts

### DIFF
--- a/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
@@ -8,19 +8,12 @@ Created on Wed Mar 12 15:41:03 2025
 
 # Import Libraries
 from matplotlib.colors import LogNorm
-import gc
-from tqdm import tqdm
-from pypylon import pylon
 from matplotlib import pyplot as plt
-from PIL import Image
 import numpy as np
 import time
 from astropy.io import fits
 import os
-import sys
 import scipy
-import matplotlib.animation as animation
-from pathlib import Path
 from src.config import config
 
 ROOT_DIR = config.root_dir

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -7,21 +7,12 @@ Created on Wed Feb 26 13:11:37 2025
 """
 
 # Import Libraries
-import gc
-from tqdm import tqdm
-from pypylon import pylon
 from matplotlib import pyplot as plt
-from PIL import Image
 import numpy as np
 import time
 from astropy.io import fits
 import os
-import sys
-import scipy
-from DEVICES_3.Basler_Pylon.test_pylon import *
 import dao
-from matplotlib.colors import LogNorm
-from pathlib import Path
 from src.config import config
 
 ROOT_DIR = config.root_dir


### PR DESCRIPTION
## Summary
- remove unused libraries from `dao_AO_closed_loop_with_kl_3s_pyr.py`
- remove unused libraries from `dao_linearity_curve_3s_pyr.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_687995b038748330abb2a98d632f9c48