### PR TITLE
Sync DM commands to shared memory

### DIFF
--- a/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
@@ -77,7 +77,11 @@ print("Number of DM modes =", nmodes_dm)
 
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
-deformable_mirror.actuators.fill(1)
+set_dm_actuators(
+    deformable_mirror,
+    np.ones(deformable_mirror.num_actuators),
+    setup=setup,
+)
 plt.figure()
 plt.imshow(deformable_mirror.surface.shaped)
 plt.colorbar()

--- a/scripts_with_dao/dao_cross_correlation_3s_pyr.py
+++ b/scripts_with_dao/dao_cross_correlation_3s_pyr.py
@@ -78,7 +78,11 @@ print("Number of DM modes =", nmodes_dm)
 
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
-deformable_mirror.actuators.fill(1)
+set_dm_actuators(
+    deformable_mirror,
+    np.ones(deformable_mirror.num_actuators),
+    setup=setup,
+)
 plt.imshow(deformable_mirror.surface.shaped)
 plt.colorbar()
 plt.title('Deformable Mirror Surface')

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -116,7 +116,11 @@ for mode in range(num_modes):
 
         # Put the KL mode on the DM
         deformable_mirror.flatten()
-        deformable_mirror.actuators = amp * KL2Act[mode]
+        set_dm_actuators(
+            deformable_mirror,
+            amp * KL2Act[mode],
+            setup=setup,
+        )
 
         # Create and update SLM data with current phase settings
         data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)

--- a/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
@@ -101,6 +101,7 @@ print(f"Time to create DM: {t1 - t0:.4f} s")
 # Flatten the deformable mirror surface
 deformable_mirror.flatten()
 deformable_mirror.actuators[10] = 1  # Set actuator 10 to 1
+set_dm_actuators(deformable_mirror, deformable_mirror.actuators, setup=setup)
 plt.figure()
 plt.imshow(deformable_mirror.surface.shaped)
 plt.colorbar()

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
@@ -72,7 +72,11 @@ print("Number of DM modes =", nmodes_dm)
 
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
-deformable_mirror.actuators.fill(1)
+set_dm_actuators(
+    deformable_mirror,
+    np.ones(deformable_mirror.num_actuators),
+    setup=setup,
+)
 plt.figure()
 plt.imshow(deformable_mirror.surface.shaped)
 plt.colorbar()

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
@@ -80,7 +80,11 @@ print("Number of DM modes =", nmodes_dm)
 
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
-deformable_mirror.actuators.fill(1)
+set_dm_actuators(
+    deformable_mirror,
+    np.ones(deformable_mirror.num_actuators),
+    setup=setup,
+)
 plt.figure()
 plt.imshow(deformable_mirror.surface.shaped)
 plt.colorbar()

--- a/scripts_with_dao/dao_test_DM_units.py
+++ b/scripts_with_dao/dao_test_DM_units.py
@@ -11,13 +11,18 @@ import dao
 from src.dao_setup import init_setup
 setup = init_setup()  # Import all variables from setup
 from src.utils import *
+from src.utils import set_dm_actuators
 
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
 
 deformable_mirror.flatten()
 desired_opd = 1e-9 # 100 nm OPD
-deformable_mirror.actuators = desired_opd * np.ones(nact**2)/ 2
+set_dm_actuators(
+    deformable_mirror,
+    desired_opd * np.ones(nact**2) / 2,
+    setup=setup,
+)
 
 plt.figure()
 plt.imshow(deformable_mirror.opd.shaped)

--- a/scripts_with_dao/dao_testing_DM_tip_tilt.py
+++ b/scripts_with_dao/dao_testing_DM_tip_tilt.py
@@ -73,7 +73,11 @@ y0 = None  # Reference y-coordinate
 for amp in np.arange(0, 15, 1):
     data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
     deformable_mirror.flatten()
-    deformable_mirror.actuators = amp * KL2Act[1]
+    set_dm_actuators(
+        deformable_mirror,
+        amp * KL2Act[1],
+        setup=setup,
+    )
     data_dm[:, :] = deformable_mirror.opd.shaped / 2
 
     # Display DM Data on SLM

--- a/src/KL_basis/KL_basis_ferreira_2018_v2.py
+++ b/src/KL_basis/KL_basis_ferreira_2018_v2.py
@@ -13,6 +13,7 @@ from hcipy import (
 from src.hardware import DeformableMirror
 import numpy as np
 import matplotlib.pyplot as plt
+from src.utils import set_dm_actuators
 get_ipython().run_line_magic('matplotlib', 'inline')
 from holoeye import detect_heds_module_path  # Move all the example files into the holoeye folder in Lib/site-packages 
 from holoeye import slmdisplaysdk
@@ -74,7 +75,8 @@ deformable_mirror = DeformableMirror(dm_modes)
 nmodes_dm = deformable_mirror.num_actuators
 print("number of modes =", nmodes_dm)
 
-deformable_mirror.actuators = np.ones((nact, nact)).flatten()
+initial_act = np.ones((nact, nact)).flatten()
+set_dm_actuators(deformable_mirror, initial_act)
 plt.imshow(deformable_mirror.surface.shaped)
 
 deformable_mirror.flatten()

--- a/src/ao_loop_functions.py
+++ b/src/ao_loop_functions.py
@@ -252,7 +252,11 @@ def closed_loop_test(num_iterations, gain, leakage, delay, data_phase_screen, an
         delayed_act_pos = act_pos_queue[-(max_buffer)]  
         
         # Apply delayed actuator command
-        deformable_mirror.actuators = (1 - leakage) * deformable_mirror.actuators - gain * delayed_act_pos
+        set_dm_actuators(
+            deformable_mirror,
+            (1 - leakage) * deformable_mirror.actuators - gain * delayed_act_pos,
+            setup=setup,
+        )
         #deformable_mirror.actuators = (1-leakage) * deformable_mirror.actuators - gain * act_pos
         
         # KL modes corresponding the total actuator postion or the DM shape

--- a/src/calibration_functions.py
+++ b/src/calibration_functions.py
@@ -4,6 +4,7 @@ import dao
 import matplotlib.pyplot as plt
 from datetime import datetime
 from src.utils import *
+from src.utils import set_dm_actuators
 from src.dao_setup import init_setup
 
 setup = init_setup()
@@ -108,7 +109,11 @@ def perform_push_pull_calibration_with_phase_basis(basis, phase_amp, ref_image, 
                 # Compute Zernike phase pattern
                 t2 = time.time()
                 deformable_mirror.flatten()
-                deformable_mirror.actuators = amp * basis[mode].reshape(nact**2)
+                set_dm_actuators(
+                    deformable_mirror,
+                    amp * basis[mode].reshape(nact**2),
+                    setup=setup,
+                )
                 data_dm[:, :] = deformable_mirror.opd.shaped/2
                 t3 = time.time()
 

--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from src.config import config
 from src.hardware import Camera, SLM, Laser, DM
 import dao
-from src.utils import compute_data_slm, set_default_setup
+from src.utils import compute_data_slm, set_default_setup, set_dm_actuators
 from src.circular_pupil_functions import create_slm_circular_pupil
 
 ROOT_DIR = config.root_dir
@@ -186,7 +186,7 @@ data_othermodes = np.sum(othermodes_matrix, axis=0)
 #Put the modes on the dm
 data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
 deformable_mirror.flatten()
-deformable_mirror.actuators = data_tt + data_othermodes  # Add TT and higher-order terms to pupil
+set_dm_actuators(deformable_mirror, data_tt + data_othermodes, setup=setup)
 data_dm[:, :] = deformable_mirror.opd.shaped/2 #divide by 2 is very important to get the proper phase. because for this phase to be applied the slm surface needs to half of it.
 
 # Combine the DM surface with the pupil
@@ -238,7 +238,7 @@ class PupilSetup:
 
         self.data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
         deformable_mirror.flatten()
-        deformable_mirror.actuators = data_tt + data_othermodes
+        set_dm_actuators(deformable_mirror, data_tt + data_othermodes, setup=setup)
         self.data_dm[:, :] = deformable_mirror.opd.shaped / 2
 
         self.data_pupil_outer = np.copy(self.data_pupil)

--- a/src/flux_filtering_mask_functions.py
+++ b/src/flux_filtering_mask_functions.py
@@ -12,7 +12,7 @@ import os
 from matplotlib import pyplot as plt
 from src.dao_setup import init_setup
 from src.tilt_functions import apply_intensity_tilt_kl
-from src.utils import compute_data_slm
+from src.utils import compute_data_slm, set_dm_actuators
 import matplotlib.colors as mcolors
 from astropy.io import fits
 
@@ -72,7 +72,7 @@ def create_summed_image_for_mask(modulation_angles, modulation_amp, tiltx, tilty
         # Put on DM
         data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
         deformable_mirror.flatten()
-        deformable_mirror.actuators = data_modulation  
+        set_dm_actuators(deformable_mirror, data_modulation, setup=setup)
         data_dm[:, :] = deformable_mirror.opd.shaped/2
         data_slm = compute_data_slm(data_dm=data_dm, setup=setup.pupil_setup)
         slm.set_data(data_slm)
@@ -123,7 +123,7 @@ def create_summed_image_for_mask_dm_random(n_iter, verbose=False, **kwargs):
             print(f"Iteration {i + 1}")
 
         act_random = np.random.choice([0, 1], size=nact_total)
-        deformable_mirror.actuators = act_random
+        set_dm_actuators(deformable_mirror, act_random, setup=setup)
         data_dm[:, :] = deformable_mirror.opd.shaped/2
         
         data_slm = compute_data_slm(data_dm=data_dm, setup=setup.pupil_setup)

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,6 +19,22 @@ def set_default_setup(setup):
     DEFAULT_SETUP = setup
 
 
+def set_dm_actuators(dm, actuators, setup=None):
+    """Set DM actuators and update the shared memory grid."""
+    from src.create_shared_memories import dm_act_shm
+
+    dm.actuators = actuators
+    if setup is None:
+        if DEFAULT_SETUP is None:
+            raise ValueError("No setup provided and no default registered.")
+        setup = DEFAULT_SETUP
+    dm_act_shm.set_data(
+        np.asarray(dm.actuators).reshape(
+            setup.npix_small_pupil_grid, setup.npix_small_pupil_grid
+        )
+    )
+
+
 # Add and wrap data within the pupil mask
 
 def compute_data_slm(data_dm=0, data_phase_screen=0, setup=None, **kwargs):


### PR DESCRIPTION
## Summary
- keep `dm_act_shm` updated whenever `deformable_mirror.actuators` is set
- reshape the 1-D actuator vector to the 2-D DM grid before writing
- wrap update logic in new `set_dm_actuators` helper
- use helper across calibration and test scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687999c7162c8330ac1783fe83a306a6