### PR TITLE
Add push_pull flags to response matrix API

### DIFF
--- a/src/calibration_functions.py
+++ b/src/calibration_functions.py
@@ -251,6 +251,8 @@ def create_response_matrix(
     verbose_plot=False,
     mode_repetitions=None,
     calibration_repetitions=1,
+    push_pull=False,
+    pull_push=True,
     **kwargs,
 ):
     """
@@ -282,6 +284,10 @@ def create_response_matrix(
     calibration_repetitions : int
         Number of times to repeat the whole calibration process. The returned
         response matrices are the average over these runs.
+    push_pull : bool
+        If True, perform a push followed by a pull ([-phase_amp, phase_amp]).
+    pull_push : bool
+        If True, perform a pull followed by a push ([phase_amp, -phase_amp]).
     kwargs:
         - pupil_size
         - nact
@@ -313,6 +319,9 @@ def create_response_matrix(
             verbose=verbose,
             verbose_plot=verbose_plot,
             mode_repetitions=mode_repetitions,
+            push_pull=push_pull,
+            pull_push=pull_push,
+            **kwargs,
         )
 
         # Initialize accumulators using first run dimensions


### PR DESCRIPTION
## Summary
- allow configuring push-pull order in `create_response_matrix`
- document new parameters
- propagate options when calling push-pull calibration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m py_compile scripts_with_dao/dao_calibrations_file.py`


------
https://chatgpt.com/codex/tasks/task_e_687f503316948330bc7e8faf33543a30