### PR TITLE
Flatten DM inside set_data_dm

### DIFF
--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -115,22 +115,11 @@ for mode in range(num_modes):
     for i, amp in enumerate(applied_phase_amp):
 
         # Put the KL mode on the DM
-        deformable_mirror.flatten()
         kl_mode = amp * KL2Act[mode]
-        set_dm_actuators(
-            deformable_mirror,
+        data_dm, data_slm = set_data_dm(
             kl_mode,
             setup=setup,
         )
-
-        # Create and update SLM data with current phase settings
-        data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
-        data_dm[:, :] = deformable_mirror.opd.shaped
-
-        # Put data_dm on the SLM
-        data_slm = compute_data_slm(data_dm=data_dm)
-        slm.set_data(data_slm)
-        time.sleep(wait_time)
 
         # Capture image and compute slopes
         slopes_image = get_slopes_image(

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -114,12 +114,11 @@ for mode in range(num_modes):
     
     for i, amp in enumerate(applied_phase_amp):
 
-        # Put the KL mode on the DM
+        # Compute the KL mode actuator positions
         kl_mode = amp * KL2Act[mode]
-        data_dm, data_slm = set_data_dm(
-            kl_mode,
-            setup=setup,
-        )
+
+        # Put KL mode on the DM
+        set_data_dm(kl_mode, setup=setup,)
 
         # Capture image and compute slopes
         slopes_image = get_slopes_image(

--- a/scripts_with_dao/dao_testing_DM_tip_tilt.py
+++ b/scripts_with_dao/dao_testing_DM_tip_tilt.py
@@ -71,20 +71,11 @@ KL2Phs = fits.getdata(os.path.join(folder_transformation_matrices, f'KL2Phs_nkl_
 y0 = None  # Reference y-coordinate
 
 for amp in np.arange(0, 15, 1):
-    data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
-    deformable_mirror.flatten()
     kl_mode = amp * KL2Act[1]
-    set_dm_actuators(
-        deformable_mirror,
+    data_dm, data_slm = set_data_dm(
         kl_mode,
         setup=setup,
     )
-    data_dm[:, :] = deformable_mirror.opd.shaped / 2
-
-    # Display DM Data on SLM
-    data_slm = compute_data_slm(data_dm=data_dm)
-    slm.set_data(data_slm)
-    time.sleep(wait_time)
 
     img = camera_fp.get_data()
 

--- a/src/calibration_functions.py
+++ b/src/calibration_functions.py
@@ -6,7 +6,7 @@ import dao
 import matplotlib.pyplot as plt
 from datetime import datetime
 from src.utils import *
-from src.utils import set_dm_actuators
+from src.utils import set_data_dm
 from src.dao_setup import init_setup
 from src.create_shared_memories import *
 
@@ -131,21 +131,15 @@ def perform_push_pull_calibration_with_phase_basis(
                 for amp in order:
                     # Compute Zernike phase pattern
                     t2 = time.time()
-                    deformable_mirror.flatten()
                     kl_mode = amp * basis[mode].reshape(nact**2)
-                    set_dm_actuators(
-                        deformable_mirror,
+                    t3 = time.time()
+
+                    # Send DM data to the SLM
+                    t4 = time.time()
+                    data_dm, data_slm = set_data_dm(
                         kl_mode,
                         setup=setup,
                     )
-                    data_dm[:, :] = deformable_mirror.opd.shaped/2
-                    t3 = time.time()
-
-                    # Add and wrap data within the pupil mask
-                    t4 = time.time()
-                    data_slm = compute_data_slm(data_dm=data_dm, setup=setup.pupil_setup)
-                    slm.set_data(data_slm)
-                    time.sleep(wait_time)
                     t7 = time.time()
 
                     # Capture the image and compute slopes

--- a/src/flux_filtering_mask_functions.py
+++ b/src/flux_filtering_mask_functions.py
@@ -12,7 +12,7 @@ import os
 from matplotlib import pyplot as plt
 from src.dao_setup import init_setup
 from src.tilt_functions import apply_intensity_tilt_kl
-from src.utils import compute_data_slm, set_dm_actuators
+from src.utils import set_data_dm
 import matplotlib.colors as mcolors
 from astropy.io import fits
 
@@ -70,12 +70,10 @@ def create_summed_image_for_mask(modulation_angles, modulation_amp, tiltx, tilty
         data_modulation = modulation_amp * modulation_step
         
         # Put on DM
-        data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
-        deformable_mirror.flatten()
-        set_dm_actuators(deformable_mirror, data_modulation, setup=setup)
-        data_dm[:, :] = deformable_mirror.opd.shaped/2
-        data_slm = compute_data_slm(data_dm=data_dm, setup=setup.pupil_setup)
-        slm.set_data(data_slm)
+        data_dm, data_slm = set_data_dm(
+            data_modulation,
+            setup=setup,
+        )
 
         time.sleep(wait_time)  # wait for SLM update
 
@@ -123,11 +121,10 @@ def create_summed_image_for_mask_dm_random(n_iter, verbose=False, **kwargs):
             print(f"Iteration {i + 1}")
 
         act_random = np.random.choice([0, 1], size=nact_total)
-        set_dm_actuators(deformable_mirror, act_random, setup=setup)
-        data_dm[:, :] = deformable_mirror.opd.shaped/2
-        
-        data_slm = compute_data_slm(data_dm=data_dm, setup=setup.pupil_setup)
-        slm.set_data(data_slm)
+        data_dm, data_slm = set_data_dm(
+            act_random,
+            setup=setup,
+        )
         time.sleep(wait_time)
         
         img = camera.get_data()

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,7 @@ Created on Mon Sep  2 16:57:48 2024
 """
 
 import os
+import time
 import numpy as np
 from astropy.io import fits
 from scipy.ndimage import center_of_mass
@@ -71,6 +72,69 @@ def compute_data_slm(data_dm=0, data_phase_screen=0, setup=None, **kwargs):
 
     return data_slm.astype(np.uint8)
 
+# ---------------------------------------------------------------------------
+def set_data_dm(actuators, *, dm=None, setup=None, slm=None,
+                npix_small_pupil_grid=None, wait_time=None):
+    """Flatten the DM, apply ``actuators`` and show the resulting phase on the SLM.
+
+    Parameters
+    ----------
+    actuators : array_like
+        Actuator values to apply.
+    dm : object, optional
+        Deformable mirror instance. Defaults to ``setup.deformable_mirror``.
+    setup : object, optional
+        DAO setup providing defaults such as ``slm`` and ``npix_small_pupil_grid``.
+    slm : object, optional
+        SLM instance. Defaults to ``setup.slm`` if available.
+    npix_small_pupil_grid : int, optional
+        Size of the DM grid. Defaults to ``setup.npix_small_pupil_grid``.
+    wait_time : float, optional
+        Delay after sending the data. Defaults to ``setup.wait_time`` or ``0``.
+
+    Returns
+    -------
+    tuple of ndarray
+        ``(data_dm, data_slm)`` arrays that were sent to the SLM.
+    """
+
+    if setup is None:
+        if DEFAULT_SETUP is None:
+            raise ValueError("No setup provided and no default registered.")
+        setup = DEFAULT_SETUP
+
+    if slm is None:
+        slm = getattr(setup, "slm", None)
+    if slm is None:
+        raise ValueError("SLM instance must be provided")
+
+    if npix_small_pupil_grid is None:
+        npix_small_pupil_grid = getattr(setup, "npix_small_pupil_grid", None)
+    if npix_small_pupil_grid is None:
+        raise ValueError("npix_small_pupil_grid must be provided")
+
+    if wait_time is None:
+        wait_time = getattr(setup, "wait_time", 0)
+
+    if dm is None:
+        dm = getattr(setup, "deformable_mirror", None)
+    if dm is None:
+        raise ValueError("Deformable mirror instance must be provided")
+
+    dm.flatten()
+    set_dm_actuators(dm, actuators, setup=setup)
+
+    data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
+    data_dm[:, :] = dm.opd.shaped / 2
+
+    pupil_setup = getattr(setup, "pupil_setup", setup)
+    data_slm = compute_data_slm(data_dm=data_dm, setup=pupil_setup)
+    slm.set_data(data_slm)
+    time.sleep(wait_time)
+
+    return data_dm, data_slm
+
+# ---------------------------------------------------------------------------
 # data_slm = data_pupil_outer.copy()
 # data_inner = ((data_pupil_inner + (data_dm)) * 256) % 256
 # data_slm[pupil_mask] = data_inner[small_pupil_mask]


### PR DESCRIPTION
## Summary
- flatten the deformable mirror in `set_data_dm`
- update calibration and mask functions to use the new helper
- remove extra `flatten()` calls in test scripts

## Testing
- `python -m py_compile src/utils.py src/calibration_functions.py src/flux_filtering_mask_functions.py scripts_with_dao/dao_linearity_curve_3s_pyr.py scripts_with_dao/dao_testing_DM_tip_tilt.py`

------
https://chatgpt.com/codex/tasks/task_e_687f569680e08330ba9a5b19adaa7313