### PR TITLE
Load shared memories via object

### DIFF
--- a/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_kl_3s_pyr.py
@@ -30,7 +30,11 @@ from src.calibration_functions import *
 from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenModes_notsquarepupil
 from src.transformation_matrices_functions import * 
 from src.psf_centring_algorithm_functions import *
-from src.create_shared_memories import *
+from src.shm_loader import shm
+num_iterations_shm = shm.num_iterations_shm
+gain_shm = shm.gain_shm
+leakage_shm = shm.leakage_shm
+delay_shm = shm.delay_shm
 from src.scan_modes_functions import scan_othermode_amplitudes
 from src.ao_loop_functions import *
 

--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -28,7 +28,17 @@ from src.calibration_functions import *
 from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenModes_notsquarepupil
 from src.transformation_matrices_functions import * 
 from src.psf_centring_algorithm_functions import *
-from src.create_shared_memories import *
+from src.shm_loader import shm
+bias_image_shm = shm.bias_image_shm
+valid_pixels_mask_shm = shm.valid_pixels_mask_shm
+npix_valid_shm = shm.npix_valid_shm
+KL2PWFS_cube_shm = shm.KL2PWFS_cube_shm
+slopes_shm = shm.slopes_shm
+KL2S_shm = shm.KL2S_shm
+S2KL_shm = shm.S2KL_shm
+reference_image_shm = shm.reference_image_shm
+normalized_ref_image_shm = shm.normalized_ref_image_shm
+reference_psf_shm = shm.reference_psf_shm
 from src.scan_modes_functions import *
 from src.ao_loop_functions import *
 

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -27,9 +27,8 @@ from src.flux_filtering_mask_functions import *
 from src.tilt_functions import *
 from src.calibration_functions import *
 from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenModes_notsquarepupil
-from src.transformation_matrices_functions import * 
+from src.transformation_matrices_functions import *
 from src.psf_centring_algorithm_functions import *
-from src.create_shared_memories import *
 from src.scan_modes_functions import scan_othermode_amplitudes
 from src.ao_loop_functions import *
 

--- a/scripts_with_dao/dao_testing_DM_tip_tilt.py
+++ b/scripts_with_dao/dao_testing_DM_tip_tilt.py
@@ -32,7 +32,6 @@ from src.calibration_functions import *
 from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenModes_notsquarepupil
 from src.transformation_matrices_functions import * 
 from src.psf_centring_algorithm_functions import *
-from src.create_shared_memories import *
 from src.scan_modes_functions import *
 from src.ao_loop_functions import *
 

--- a/src/ao_loop_functions.py
+++ b/src/ao_loop_functions.py
@@ -15,9 +15,18 @@ from matplotlib.colors import LogNorm
 from src.utils import *
 from collections import deque
 from src.dao_setup import init_setup
+from .shm_loader import shm
 
 setup = init_setup()
-from src.create_shared_memories import *
+dm_phase_shm = shm.dm_phase_shm
+phase_screen_shm = shm.phase_screen_shm
+phase_residuals_shm = shm.phase_residuals_shm
+residual_modes_shm = shm.residual_modes_shm
+slopes_image_shm = shm.slopes_image_shm
+normalized_psf_shm = shm.normalized_psf_shm
+computed_modes_shm = shm.computed_modes_shm
+commands_shm = shm.commands_shm
+dm_kl_modes_shm = shm.dm_kl_modes_shm
 
 
 def closed_loop_test(num_iterations, gain, leakage, delay, data_phase_screen, anim_path, aim_name, anim_title,

--- a/src/calibration_functions.py
+++ b/src/calibration_functions.py
@@ -8,7 +8,9 @@ from datetime import datetime
 from src.utils import *
 from src.utils import set_data_dm
 from src.dao_setup import init_setup
-from src.create_shared_memories import *
+from .shm_loader import shm
+
+slopes_image_shm = shm.slopes_image_shm
 
 setup = init_setup()
 

--- a/src/common_imports.py
+++ b/src/common_imports.py
@@ -37,7 +37,11 @@ from src.calibration_functions import *
 from src.kl_basis_eigenmodes_functions import computeEigenModes, computeEigenModes_notsquarepupil
 from src.transformation_matrices_functions import *
 from src.psf_centring_algorithm_functions import *
-from src.create_shared_memories import *
+from .shm_loader import shm
+
+for name, handle in vars(shm).items():
+    if name.endswith('_shm'):
+        globals()[name] = handle
 from src.scan_modes_functions import *
 from src.ao_loop_functions import *
 

--- a/src/create_transformation_matrices.py
+++ b/src/create_transformation_matrices.py
@@ -23,7 +23,10 @@ import dao
 from src.dao_setup import init_setup
 import src.dao_setup as dao_setup
 from src.transformation_matrices_functions import *
-from src.create_shared_memories import *
+from .shm_loader import shm
+
+KL2Act_shm = shm.KL2Act_shm
+KL2Phs_shm = shm.KL2Phs_shm
 
 setup = init_setup()
 

--- a/src/shm_loader.py
+++ b/src/shm_loader.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import dao
+import toml
+
+class ShmLoader:
+    def __init__(self, toml_path: str | Path | None = None):
+        if toml_path is None:
+            toml_path = Path(__file__).with_name("shm_path.toml")
+        self.toml_path = Path(toml_path)
+        self.init_shm()
+
+    def init_shm(self):
+        with open(self.toml_path, 'r') as f:
+            shm_path = toml.load(f)
+        self.slopes_image_shm   = dao.shm(shm_path['slopes_image'])
+        self.phase_screen_shm   = dao.shm(shm_path['phase_screen'])
+        self.dm_phase_shm       = dao.shm(shm_path['dm_phase'])
+        self.phase_residuals_shm= dao.shm(shm_path['phase_residuals'])
+        self.normalized_psf_shm = dao.shm(shm_path['normalized_psf'])
+        self.commands_shm       = dao.shm(shm_path['commands'])
+        self.residual_modes_shm = dao.shm(shm_path['residual_modes'])
+        self.computed_modes_shm = dao.shm(shm_path['computed_modes'])
+        self.dm_kl_modes_shm    = dao.shm(shm_path['dm_kl_modes'])
+        self.delay_shm          = dao.shm(shm_path['delay'])
+        self.gain_shm           = dao.shm(shm_path['gain'])
+        self.leakage_shm        = dao.shm(shm_path['leakage'])
+        self.num_iterations_shm = dao.shm(shm_path['num_iterations'])
+        self.cam1_shm           = dao.shm(shm_path['cam1'])
+        self.cam2_shm           = dao.shm(shm_path['cam2'])
+
+shm = ShmLoader()
+
+__all__ = ["ShmLoader", "shm"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,6 +12,8 @@ from astropy.io import fits
 from scipy.ndimage import center_of_mass
 from scipy.interpolate import interp2d
 
+from .shm_loader import shm
+
 DEFAULT_SETUP = None
 
 def set_default_setup(setup):
@@ -22,7 +24,7 @@ def set_default_setup(setup):
 
 def set_dm_actuators(dm, actuators, setup=None):
     """Set DM actuators and update the shared memory grid."""
-    from src.create_shared_memories import dm_act_shm
+    dm_act_shm = shm.dm_act_shm
 
     dm.actuators = actuators
     if setup is None:
@@ -260,7 +262,7 @@ def get_slopes_image(mask, bias_image, normalized_reference_image, pyr_img=None,
         The computed slopes image.
     """
 
-    from src.create_shared_memories import slopes_img_shm
+    slopes_img_shm = shm.slopes_img_shm
 
     if setup is None:
         if DEFAULT_SETUP is None:


### PR DESCRIPTION
## Summary
- provide `ShmLoader` class with `init_shm` for loading handles from `shm_path.toml`
- map shared memory attributes in `common_imports` and other modules
- replace previous `load_shm_handles` usage in utilities and scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687f6f5048ac83308040f41407d3bdd4