### PR TITLE
Handle default DM actuators

### DIFF
--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -84,7 +84,7 @@ time.sleep(5)
 # slm.set_data(data_slm)
 # time.sleep(wait_time)
 
-set_data_dm(actuators=setup.dm_flat, setup=setup)
+set_data_dm(setup=setup)
 
 print('Pupil created on the SLM.')
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -22,20 +22,29 @@ def set_default_setup(setup):
     DEFAULT_SETUP = setup
 
 
-def set_dm_actuators(dm, actuators, setup=None):
+def set_dm_actuators(dm, actuators=None, dm_flat=None, setup=None):
     """Set DM actuators and update the shared memory grid."""
-    dm_act_shm = shm.dm_act_shm
 
-    dm.actuators = actuators
     if setup is None:
         if DEFAULT_SETUP is None:
             raise ValueError("No setup provided and no default registered.")
         setup = DEFAULT_SETUP
-    dm_act_shm.set_data(
-        np.asarray(dm.actuators).reshape(
-            setup.nact, setup.nact
+
+    if actuators is None:
+        actuators = np.zeros(setup.nact ** 2)
+    if dm_flat is None:
+        dm_flat = setup.dm_flat
+
+    actuators = np.asarray(actuators)
+    if actuators.size != setup.nact ** 2:
+        raise ValueError(
+            f"Expected {setup.nact ** 2} actuators, got {actuators.size}"
         )
-    )
+
+    dm.actuators = actuators + dm_flat
+
+    dm_act_shm = shm.dm_act_shm
+    dm_act_shm.set_data(np.asarray(dm.actuators).reshape(setup.nact, setup.nact))
     
 
 


### PR DESCRIPTION
## Summary
- update `set_dm_actuators` so actuator and flat arrays are optional
- use default DM flat in calibration script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_68834d3a0fac83308789f71a6cbb22e2