### PR TITLE
Update DM utilities and clean headers

### DIFF
--- a/scripts_with_dao/slm_tests.py
+++ b/scripts_with_dao/slm_tests.py
@@ -6,14 +6,6 @@ Created on Mon May 19 10:16:49 2025
 @author: ristretto-dao
 """
 
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Mon Feb 17 14:49:20 2025
-
-@author: laboptic
-"""
-
 # Import Libraries
 import os
 import time

--- a/src/utils.py
+++ b/src/utils.py
@@ -85,13 +85,16 @@ def compute_data_slm(data_dm=0, data_phase_screen=0, data_dm_flat=0, setup=None,
     return data_slm.astype(np.uint8)
 
 # ---------------------------------------------------------------------------
-def set_data_dm(actuators, *, setup=None, **kwargs):
-    """Flatten the DM, apply ``actuators`` and show the resulting phase on the SLM.
+def set_data_dm(actuators=None, *, setup=None, dm_flat=None, **kwargs):
+    """Flatten the DM, optionally apply ``actuators`` and show the resulting
+    phase on the SLM.
 
     Parameters
     ----------
-    actuators : array_like
-        Actuator values to apply.
+    actuators : array_like, optional
+        Actuator values to apply. Defaults to zeros.
+    dm_flat : array_like, optional
+        Flat map added to the actuators. Defaults to ``setup.dm_flat``.
     setup : object, optional
         DAO setup providing defaults for devices and dimensions.
     kwargs : optional
@@ -130,7 +133,7 @@ def set_data_dm(actuators, *, setup=None, **kwargs):
         raise ValueError("Deformable mirror instance must be provided")
 
     dm.flatten()
-    set_dm_actuators(dm, actuators, setup=setup)
+    set_dm_actuators(dm, actuators, dm_flat=dm_flat, setup=setup)
 
     data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
     data_dm[:, :] = dm.opd.shaped / 2


### PR DESCRIPTION
## Summary
- make `set_data_dm` accept optional `actuators` argument
- add `dm_flat` keyword to `set_data_dm`
- clean duplicate header in `slm_tests.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688358d9ed908330bae15ff259445047