### PR TITLE
Fix dm_flat attribute in PupilSetup

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -235,6 +235,7 @@ class PupilSetup:
         # Store masks for later use when recomputing the pupil
         self.pupil_mask = pupil_mask
         self.small_pupil_mask = small_pupil_mask
+        self.dm_flat = dm_flat
         self.data_slm = compute_data_slm(setup=self)
 
     def _recompute_dm(self):


### PR DESCRIPTION
## Summary
- update `PupilSetup` to hold a reference to `dm_flat`

## Testing
- `python -m py_compile src/dao_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6886654caa38833090316a04718352e9