### PR TITLE
Add kwargs support for DM random acquisition

### DIFF
--- a/src/flux_filtering_mask_functions.py
+++ b/src/flux_filtering_mask_functions.py
@@ -68,7 +68,7 @@ def create_summed_image_for_mask(modulation_angles, modulation_amp, tiltx, tilty
     return summed_image
 
 
-def create_summed_image_for_mask_dm_random(n_iter, camera=None, nact_total=None, verbose=False):
+def create_summed_image_for_mask_dm_random(n_iter, verbose=False, **kwargs):
     """Acquire a summed image using random DM actuator patterns.
 
     Parameters
@@ -76,9 +76,9 @@ def create_summed_image_for_mask_dm_random(n_iter, camera=None, nact_total=None,
     n_iter : int
         Number of random actuator patterns to apply.
     camera : optional
-        Camera object used for acquisition. Defaults to ``setup.camera_wfs``.
+        Camera object used for acquisition (default ``setup.camera_wfs``).
     nact_total : int, optional
-        Number of DM actuators. Defaults to ``setup.nact_total``.
+        Number of DM actuators (default ``setup.nact_total``).
     verbose : bool, optional
         If ``True`` display progress information.
 
@@ -88,10 +88,9 @@ def create_summed_image_for_mask_dm_random(n_iter, camera=None, nact_total=None,
         Summed image produced by random push--pull modulation.
     """
 
-    if camera is None:
-        camera = setup.camera_wfs
-    if nact_total is None:
-        nact_total = setup.nact_total
+    # Use kwargs or defaults from setup
+    camera = kwargs.get("camera", setup.camera_wfs)
+    nact_total = kwargs.get("nact_total", setup.nact_total)
 
     img_arr = []
 
@@ -167,6 +166,7 @@ def create_flux_filtering_mask(method, flux_cutoff, tiltx, tilty,
             summed_image = create_summed_image_for_mask_dm_random(
                 n_iter=n_iter,
                 verbose=verbose,
+                **kwargs,
             )
         else:
             raise ValueError("Invalid method. Use 'tip_tilt_modulation' or 'dm_random'.")


### PR DESCRIPTION
## Summary
- allow `create_summed_image_for_mask_dm_random` to load `camera` and `nact_total` from kwargs
- forward kwargs from `create_flux_filtering_mask`

## Testing
- `python3 -m py_compile src/flux_filtering_mask_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_68868cf4de2083309d7967546c712178