### PR TITLE
Return DM actuators from update_pupil

### DIFF
--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -16,6 +16,7 @@ from src.config import config
 ROOT_DIR = config.root_dir
 
 from src.dao_setup import init_setup, ROOT_DIR
+from src.utils import set_data_dm
 
 setup = init_setup()
 wait_time = setup.wait_time
@@ -58,8 +59,8 @@ def cost_function(amplitudes, pupil_coords, radius, iteration, variance_threshol
     """
     global stop_optimization  #Flag to stop when pupil intensities are equal
 
-    data_slm = pupil_setup.update_pupil(new_tt_amplitudes=amplitudes)
-    slm.set_data(data_slm)  # Update SLM data
+    act_pos = pupil_setup.update_pupil(new_tt_amplitudes=amplitudes)
+    set_data_dm(actuators=act_pos, setup=setup)
     time.sleep(wait_time)  # Wait for the update to take effect
 
     # Capture and average 5 images

--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -2,6 +2,7 @@ import time
 import numpy as np
 
 from src.dao_setup import init_setup, ROOT_DIR
+from src.utils import set_data_dm
 
 setup = init_setup()
 wait_time = setup.wait_time
@@ -54,8 +55,8 @@ def scan_othermode_amplitudes(test_values, mode_index, wait=wait_time,
         new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        slm_data = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
-        slm.set_data(slm_data)
+        act_pos = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
+        set_data_dm(actuators=act_pos, setup=setup)
         time.sleep(wait)
 
         # Capture focal-plane image and log stats
@@ -148,8 +149,8 @@ def scan_othermode_amplitudes_wfs_std(test_values, mode_index, mask, wait=wait_t
         new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        slm_data = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
-        slm.set_data(slm_data)
+        act_pos = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
+        set_data_dm(actuators=act_pos, setup=setup)
         time.sleep(wait)
 
         # Capture WFS images and compute standard deviation over valid pixels


### PR DESCRIPTION
## Summary
- have `PupilSetup.update_pupil` return the DM actuator positions computed by `_recompute_dm`
- update the PSF centering and scan helpers to use `set_data_dm` with the returned actuators

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68868deed21883309932cf4060812fc9