### PR TITLE
Expose DM actuators when updating pupil

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -232,6 +232,7 @@ class PupilSetup:
         self.data_pupil_outer = data_pupil_outer
         self.data_pupil_inner = data_pupil_inner
         self.data_pupil_inner_new = data_pupil_inner_new
+        self.actuators = np.zeros(nact**2)
         # Store masks for later use when recomputing the pupil
         self.pupil_mask = pupil_mask
         self.small_pupil_mask = small_pupil_mask
@@ -251,6 +252,7 @@ class PupilSetup:
         # deformable_mirror.actuators = data_tt + data_othermodes  # Add TT and higher-order terms to pupil
         actuators = data_tt + data_othermodes
         set_dm_actuators(deformable_mirror, actuators, setup=self)
+        self.actuators = actuators
         self.data_dm[:, :] = deformable_mirror.opd.shaped / 2
 
         self.data_pupil_outer = np.copy(self.data_pupil)
@@ -283,7 +285,7 @@ class PupilSetup:
         )
         self.data_pupil = self.data_pupil + self.data_focus
         self._recompute_dm()
-        return self.data_slm
+        return self.data_slm, self.actuators
 
 
 pupil_setup = PupilSetup()

--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -58,7 +58,7 @@ def cost_function(amplitudes, pupil_coords, radius, iteration, variance_threshol
     """
     global stop_optimization  #Flag to stop when pupil intensities are equal
 
-    data_slm = pupil_setup.update_pupil(new_tt_amplitudes=amplitudes)
+    data_slm, _ = pupil_setup.update_pupil(new_tt_amplitudes=amplitudes)
     slm.set_data(data_slm)  # Update SLM data
     time.sleep(wait_time)  # Wait for the update to take effect
 

--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -54,7 +54,7 @@ def scan_othermode_amplitudes(test_values, mode_index, wait=wait_time,
         new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        slm_data = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
+        slm_data, _ = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
         slm.set_data(slm_data)
         time.sleep(wait)
 
@@ -148,7 +148,7 @@ def scan_othermode_amplitudes_wfs_std(test_values, mode_index, mask, wait=wait_t
         new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        slm_data = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
+        slm_data, _ = pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
         slm.set_data(slm_data)
         time.sleep(wait)
 


### PR DESCRIPTION
## Summary
- store DM actuator values in `PupilSetup`
- return the actuators alongside `data_slm` from `update_pupil`
- adapt optimisation functions to unpack the new return tuple

## Testing
- `python -m py_compile src/dao_setup.py src/scan_modes_functions.py src/psf_centring_algorithm_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_68869ed07ca0833098df2b8f0418def8