### PR TITLE
Remove unused pupil_inner_new references

### DIFF
--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -216,7 +216,6 @@ data_pupil_inner = np.copy(
 data_pupil_inner[~small_pupil_mask] = 0  # Zero out region outside the mask
 
 # Wrap and insert DM data into the pupil
-data_pupil_inner_new = data_pupil_inner + data_dm
 
 
 class PupilSetup:
@@ -236,13 +235,12 @@ class PupilSetup:
         self.nact = nact
         self.data_pupil_outer = data_pupil_outer
         self.data_pupil_inner = data_pupil_inner
-        self.data_pupil_inner_new = data_pupil_inner_new
         self.actuators = np.zeros(nact**2)
         # Store masks for later use when recomputing the pupil
         self.pupil_mask = pupil_mask
         self.small_pupil_mask = small_pupil_mask
         self.dm_flat = dm_flat
-        self.data_slm = compute_data_slm()
+        self.data_slm = compute_data_slm(setup=self)
 
     def _recompute_dm(self):
         """(Re)compute DM contribution and assemble the pupil."""
@@ -271,7 +269,6 @@ class PupilSetup:
                              offset_width:offset_width + npix_small_pupil_grid])
         self.data_pupil_inner[~self.small_pupil_mask] = 0
 
-        self.data_pupil_inner_new = self.data_pupil_inner + self.data_dm
 
 
     def update_pupil(self, new_tt_amplitudes=None, new_othermodes_amplitudes=None,

--- a/src/utils.py
+++ b/src/utils.py
@@ -24,13 +24,13 @@ def set_default_setup(setup):
 
 
 
-def compute_data_slm(data_dm=0, data_phase_screen=0, data_dm_flat=0, setup=None, **kwargs):
+def compute_data_slm(data_dm=None, data_phase_screen=0, data_dm_flat=0, setup=None, **kwargs):
     """
     Computes the SLM data by combining phase screen and deformable mirror data
     with pupil-related masks and arrays.
 
     Parameters:
-    - data_dm (float or ndarray): Deformable mirror phase data (default: 0).
+    - data_dm (float or ndarray, optional): Deformable mirror phase data. If ``None``, ``setup.data_dm`` is used.
     - data_phase_screen (float or ndarray): Phase screen data to add (default: 0).
     - **kwargs:
         - data_pupil_inner (ndarray): Inner pupil data array.
@@ -47,7 +47,9 @@ def compute_data_slm(data_dm=0, data_phase_screen=0, data_dm_flat=0, setup=None,
             raise ValueError("No setup provided and no default registered.")
         setup = DEFAULT_SETUP
 
-    data_pupil_inner = kwargs.get("data_pupil_inner", setup.data_pupil_inner_new)
+    if data_dm is None:
+        data_dm = setup.data_dm
+    data_pupil_inner = kwargs.get("data_pupil_inner", setup.data_pupil_inner)
     data_pupil_outer = kwargs.get("data_pupil_outer", setup.data_pupil_outer)
     pupil_mask = kwargs.get("pupil_mask", setup.pupil_mask)
     small_pupil_mask = kwargs.get("small_pupil_mask", setup.small_pupil_mask)


### PR DESCRIPTION
## Summary
- stop storing a redundant `data_pupil_inner_new`
- compute SLM data from `data_pupil_inner` and DM phase

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6886cc4a96508330973bfc690f21901f