### PR TITLE
Revise pupil update logic

### DIFF
--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -58,8 +58,8 @@ def cost_function(amplitudes, pupil_coords, radius, iteration, variance_threshol
     """
     global stop_optimization  # Flag to stop when pupil intensities are equal
 
-    actuators = pupil_setup.update_pupil(new_tt_amplitudes=amplitudes)
-    # set_data_dm(setup=setup)
+    pupil_setup.update_pupil(tt_amplitudes=amplitudes)
+    # Apply the updated flat map to the DM and SLM
     set_data_dm(setup=setup)
 
     # Capture and average 5 images

--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -54,7 +54,7 @@ def scan_othermode_amplitudes(test_values, mode_index, wait=wait_time,
         new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
+        pupil_setup.update_pupil(othermodes_amplitudes=new_amps)
         set_data_dm(setup=setup)
 
         # Capture focal-plane image and log stats
@@ -94,12 +94,12 @@ def scan_othermode_amplitudes(test_values, mode_index, wait=wait_time,
             with open(dao_setup_path, 'w') as file:
                 file.write(updated_content)
             print('Updated `othermodes_amplitudes` in dao_setup.py')
-            pupil_setup.update_pupil(new_othermodes_amplitudes=values)
+            pupil_setup.update_pupil(othermodes_amplitudes=values)
         else:
             print('Failed to update `othermodes_amplitudes` in dao_setup.py')
-            pupil_setup.update_pupil(new_othermodes_amplitudes=original_amps)
+            pupil_setup.update_pupil(othermodes_amplitudes=original_amps)
     else:
-        pupil_setup.update_pupil(new_othermodes_amplitudes=original_amps)
+        pupil_setup.update_pupil(othermodes_amplitudes=original_amps)
 
     return best_amp
 
@@ -145,7 +145,7 @@ def scan_othermode_amplitudes_wfs_std(test_values, mode_index, mask,
         new_amps = list(pupil_setup.othermodes_amplitudes)
         new_amps[mode_index] = amp
 
-        pupil_setup.update_pupil(new_othermodes_amplitudes=new_amps)
+        pupil_setup.update_pupil(othermodes_amplitudes=new_amps)
         set_data_dm(setup=setup)
 
         # Capture WFS images and compute standard deviation over valid pixels
@@ -184,11 +184,11 @@ def scan_othermode_amplitudes_wfs_std(test_values, mode_index, mask,
             with open(dao_setup_path, 'w') as file:
                 file.write(updated_content)
             print('Updated `othermodes_amplitudes` in dao_setup.py')
-            pupil_setup.update_pupil(new_othermodes_amplitudes=values)
+            pupil_setup.update_pupil(othermodes_amplitudes=values)
         else:
             print('Failed to update `othermodes_amplitudes` in dao_setup.py')
-            pupil_setup.update_pupil(new_othermodes_amplitudes=original_amps)
+            pupil_setup.update_pupil(othermodes_amplitudes=original_amps)
     else:
-        pupil_setup.update_pupil(new_othermodes_amplitudes=original_amps)
+        pupil_setup.update_pupil(othermodes_amplitudes=original_amps)
 
     return best_amp


### PR DESCRIPTION
## Summary
- store DM phases in the `dm_flat` map instead of touching the hardware
- expose new `update_pupil()` API to return the flat map
- apply pupil updates via `set_data_dm` in the centring algorithm
- adjust scanning utilities for the new API

## Testing
- `python -m py_compile src/dao_setup.py src/psf_centring_algorithm_functions.py src/scan_modes_functions.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_6886db07779c83308d2121aba5e4ffcb