### PR TITLE
Refactor set_dm_actuators signature

### DIFF
--- a/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
@@ -78,7 +78,6 @@ print("Number of DM modes =", nmodes_dm)
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
 set_dm_actuators(
-    deformable_mirror,
     np.ones(deformable_mirror.num_actuators),
     setup=setup,
 )

--- a/scripts_with_dao/dao_cross_correlation_3s_pyr.py
+++ b/scripts_with_dao/dao_cross_correlation_3s_pyr.py
@@ -79,7 +79,6 @@ print("Number of DM modes =", nmodes_dm)
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
 set_dm_actuators(
-    deformable_mirror,
     np.ones(deformable_mirror.num_actuators),
     setup=setup,
 )

--- a/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
@@ -101,7 +101,7 @@ print(f"Time to create DM: {t1 - t0:.4f} s")
 # Flatten the deformable mirror surface
 deformable_mirror.flatten()
 deformable_mirror.actuators[10] = 1  # Set actuator 10 to 1
-set_dm_actuators(deformable_mirror, deformable_mirror.actuators, setup=setup)
+set_dm_actuators(deformable_mirror.actuators, setup=setup)
 plt.figure()
 plt.imshow(deformable_mirror.surface.shaped)
 plt.colorbar()

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
@@ -73,7 +73,6 @@ print("Number of DM modes =", nmodes_dm)
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
 set_dm_actuators(
-    deformable_mirror,
     np.ones(deformable_mirror.num_actuators),
     setup=setup,
 )

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
@@ -81,7 +81,6 @@ print("Number of DM modes =", nmodes_dm)
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()
 set_dm_actuators(
-    deformable_mirror,
     np.ones(deformable_mirror.num_actuators),
     setup=setup,
 )

--- a/scripts_with_dao/dao_test_DM_units.py
+++ b/scripts_with_dao/dao_test_DM_units.py
@@ -18,7 +18,6 @@ deformable_mirror.flatten()
 desired_opd = 1e-9 # 100 nm OPD
 act_pos = desired_opd * np.ones(nact**2)/ 2
 set_dm_actuators(
-    deformable_mirror,
     act_pos,
     setup=setup,
 )

--- a/src/KL_basis/KL_basis_ferreira_2018_v2.py
+++ b/src/KL_basis/KL_basis_ferreira_2018_v2.py
@@ -76,7 +76,7 @@ nmodes_dm = deformable_mirror.num_actuators
 print("number of modes =", nmodes_dm)
 
 initial_act = np.ones((nact, nact)).flatten()
-set_dm_actuators(deformable_mirror, initial_act)
+set_dm_actuators(initial_act)
 plt.imshow(deformable_mirror.surface.shaped)
 
 deformable_mirror.flatten()

--- a/src/ao_loop_functions.py
+++ b/src/ao_loop_functions.py
@@ -267,7 +267,6 @@ def closed_loop_test(num_iterations, gain, leakage, delay, data_phase_screen, an
         # deformable_mirror.actuators = (1 - leakage) * deformable_mirror.actuators - gain * delayed_act_pos
         new_act_pos = (1 - leakage) * deformable_mirror.actuators - gain * delayed_act_pos
         set_dm_actuators(
-            deformable_mirror,
             new_act_pos,
             setup=setup,
         )

--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -183,7 +183,7 @@ data_othermodes = np.sum(othermodes_matrix, axis=0)
 #Put the modes on the dm
 dm_flat = data_tt + data_othermodes
 _setup = SimpleNamespace(nact=nact, dm_flat=dm_flat)
-set_dm_actuators(deformable_mirror, dm_flat=dm_flat, setup=_setup)
+set_dm_actuators(dm_flat=dm_flat, setup=_setup)
 
 # Combine the DM surface with the pupil
 # ``data_dm`` is defined on the small pupil grid while ``data_pupil`` has the

--- a/src/dao_setup_PAPYRUS.py
+++ b/src/dao_setup_PAPYRUS.py
@@ -102,7 +102,7 @@ data_othermodes = np.sum(othermodes_matrix, axis=0)
 #Put the modes on the dm
 dm_flat = data_tt + data_othermodes
 _setup = SimpleNamespace(nact=nact, dm_flat=dm_flat)
-set_dm_actuators(deformable_mirror, dm_flat=dm_flat, setup=_setup)
+set_dm_actuators(dm_flat=dm_flat, setup=_setup)
 
 # Combine the DM surface with the pupil
 # ``data_dm`` is defined on the small pupil grid while ``data_pupil`` has the


### PR DESCRIPTION
## Summary
- refactor `set_dm_actuators` to obtain DM via kwargs or setup
- update `set_data_dm` to use new `set_dm_actuators`
- remove DM parameter from all script and module calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688749448c9c833090b3d2e3d864790d