### PR TITLE
Fix DM actuator helpers in Papyrus setup

### DIFF
--- a/src/dao_setup_PAPYRUS.py
+++ b/src/dao_setup_PAPYRUS.py
@@ -39,7 +39,12 @@ folder_turbulence = config.folder_turbulence
 folder_gui = config.folder_gui
 
 def set_dm_actuators(actuators=None, dm_flat=None, setup=None, **kwargs):
-    """Set DM actuators and update the shared memory grid."""
+    """Set DM actuators and update the shared memory grid.
+
+    If a deformable mirror instance is available it is updated as well.  When
+    running on a minimal setup (no DM hardware), the actuator pattern is simply
+    written to the shared memory segment.
+    """
 
     if setup is None:
         if DEFAULT_SETUP is None:
@@ -52,73 +57,66 @@ def set_dm_actuators(actuators=None, dm_flat=None, setup=None, **kwargs):
         dm_flat = setup.dm_flat
 
     actuators = np.asarray(actuators)
-    
-    if testplace==GENEVA:
 
-        deformable_mirror = kwargs.get("deformable_mirror", getattr(setup, "deformable_mirror", None))
-        if deformable_mirror is None:
-            raise ValueError("Deformable mirror instance must be provided")
-    
+    deformable_mirror = kwargs.get(
+        "deformable_mirror", getattr(setup, "deformable_mirror", None)
+    )
+
+    if deformable_mirror is not None:
         deformable_mirror.actuators = actuators + dm_flat
-    
-        dm_act_shm = shm.dm_act_shm
-        dm_act_shm.set_data(
-            np.asarray(deformable_mirror.actuators).astype(np.float64).reshape(
-                setup.nact, setup.nact
-            )
-        )
-        
+        actuators_to_store = deformable_mirror.actuators
     else:
-        
-        dm_act_shm = shm.dm_act_shm
-        dm_act_shm.set_data(
-            np.asarray(actuators + dm_flat).astype(np.float64).reshape(
-                setup.nact, setup.nact
-            )
+        actuators_to_store = actuators + dm_flat
+
+    dm_act_shm = shm.dm_act_shm
+    dm_act_shm.set_data(
+        np.asarray(actuators_to_store).astype(np.float64).reshape(
+            setup.nact, setup.nact
         )
+    )
 
         
         
 
 
 def set_data_dm(actuators=None, *, setup=None, dm_flat=None, **kwargs):
-    """Flatten the DM, optionally apply ``actuators`` and show the resulting phase on the SLM."""
+    """Flatten the DM, optionally apply ``actuators`` and, if available, update the SLM."""
 
     if setup is None:
         if DEFAULT_SETUP is None:
             raise ValueError("No setup provided and no default registered.")
         setup = DEFAULT_SETUP
-        
-    if testplace==GENEVA:
 
-        slm = kwargs.get("slm", getattr(setup, "slm", None))
-        if slm is None:
-            raise ValueError("SLM instance must be provided")
-    
-        deformable_mirror = kwargs.get("deformable_mirror", getattr(setup, "deformable_mirror", None))
-        if deformable_mirror is None:
-            raise ValueError("Deformable mirror instance must be provided")
-    
-        npix_small_pupil_grid = kwargs.get(
-            "npix_small_pupil_grid", getattr(setup, "npix_small_pupil_grid", None)
-        )
-        wait_time = kwargs.get("wait_time", getattr(setup, "wait_time", 0))
-        pupil_setup = kwargs.get("pupil_setup", getattr(setup, "pupil_setup", None))
-    
+    slm = kwargs.get("slm", getattr(setup, "slm", None))
+    deformable_mirror = kwargs.get(
+        "deformable_mirror", getattr(setup, "deformable_mirror", None)
+    )
+    npix_small_pupil_grid = kwargs.get(
+        "npix_small_pupil_grid", getattr(setup, "npix_small_pupil_grid", None)
+    )
+    wait_time = kwargs.get("wait_time", getattr(setup, "wait_time", 0))
+    pupil_setup = kwargs.get("pupil_setup", getattr(setup, "pupil_setup", None))
+
+    if deformable_mirror is not None:
         deformable_mirror.flatten()
-        set_dm_actuators(actuators, dm_flat=dm_flat, setup=setup)
-    
+
+    set_dm_actuators(
+        actuators, dm_flat=dm_flat, setup=setup, deformable_mirror=deformable_mirror
+    )
+
+    if deformable_mirror is not None and npix_small_pupil_grid is not None:
         data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
         data_dm[:, :] = deformable_mirror.opd.shaped / 2
-    
+    else:
+        data_dm = np.zeros((setup.nact, setup.nact), dtype=np.float32)
+
+    if slm is not None and pupil_setup is not None:
         data_slm = compute_data_slm(data_dm=data_dm, setup=pupil_setup)
         slm.set_data(data_slm)
         time.sleep(wait_time)
-    
         return actuators, data_dm, data_slm
-    
-    else:
-        set_dm_actuators(actuators, dm_flat=dm_flat, setup=setup)
+
+    return actuators, data_dm, None
 
 #%% Configuration Camera
 


### PR DESCRIPTION
## Summary
- implement `set_dm_actuators` and `set_data_dm` for Papyrus
- handle optional DM and SLM instances gracefully

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_68878ae4af1c8330bbdc827b379a469a