### PR TITLE
Refactor DM utilities

### DIFF
--- a/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
+++ b/scripts_with_dao/dao_AO_closed_loop_with_zernike3s_pyr.py
@@ -36,7 +36,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import init_setup, set_dm_actuators
+from src.dao_setup import init_setup
+from src.utils import set_dm_actuators
 setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *

--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -17,7 +17,8 @@ from matplotlib import pyplot as plt
 # Import Specific Modules
 import dao
 from src.config import config
-from src.dao_setup import init_setup, las, set_data_dm
+from src.dao_setup import init_setup, las
+from src.utils import set_data_dm
 setup = init_setup()
 from src.utils import *
 from src.circular_pupil_functions import *

--- a/scripts_with_dao/dao_cross_correlation_3s_pyr.py
+++ b/scripts_with_dao/dao_cross_correlation_3s_pyr.py
@@ -35,7 +35,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import init_setup, set_dm_actuators
+from src.dao_setup import init_setup
+from src.utils import set_dm_actuators
 setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr.py
@@ -19,7 +19,8 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import init_setup, set_data_dm
+from src.dao_setup import init_setup
+from src.utils import set_data_dm
 setup = init_setup()  # Import all variables from setup
 from src.utils import *
 from src.circular_pupil_functions import *

--- a/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_3s_pyr.py
@@ -32,7 +32,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import init_setup, set_dm_actuators
+from src.dao_setup import init_setup
+from src.utils import set_dm_actuators
 setup = init_setup()  # Import all variables from setup
 
 #%% Accessing Devices

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr.py
@@ -32,7 +32,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import init_setup, set_dm_actuators
+from src.dao_setup import init_setup
+from src.utils import set_dm_actuators
 setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *

--- a/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
+++ b/scripts_with_dao/dao_push-pull_calibration_zernike_3s_pyr_new.py
@@ -40,7 +40,8 @@ from src.utils import *
 from src.dao_create_flux_filtering_mask import *
 from src.psf_centring_algorithm import *
 from src.calibration_functions import *
-from src.dao_setup import init_setup, set_dm_actuators
+from src.dao_setup import init_setup
+from src.utils import set_dm_actuators
 setup = init_setup()  # Import all variables from setup
 from src.kl_basis_eigenmodes import computeEigenModes, computeEigenModes_notsquarepupil
 from src.create_transformation_matrices import *

--- a/scripts_with_dao/dao_test_DM_units.py
+++ b/scripts_with_dao/dao_test_DM_units.py
@@ -11,7 +11,7 @@ import dao
 from src.dao_setup import init_setup
 setup = init_setup()  # Import all variables from setup
 from src.utils import *
-from src.dao_setup import set_dm_actuators
+from src.utils import set_dm_actuators
 
 # Flatten the DM surface and set actuator values
 deformable_mirror.flatten()

--- a/scripts_with_dao/dao_testing_DM_tip_tilt.py
+++ b/scripts_with_dao/dao_testing_DM_tip_tilt.py
@@ -22,7 +22,8 @@ ROOT_DIR = config.root_dir
 
 # Import Specific Modules
 import dao
-from src.dao_setup import init_setup, set_data_dm
+from src.dao_setup import init_setup
+from src.utils import set_data_dm
 setup = init_setup()  # Import all variables from setup
 from src.utils import *
 from src.circular_pupil_functions import *

--- a/src/KL_basis/KL_basis_ferreira_2018_v2.py
+++ b/src/KL_basis/KL_basis_ferreira_2018_v2.py
@@ -13,7 +13,7 @@ from hcipy import (
 from src.hardware import DeformableMirror
 import numpy as np
 import matplotlib.pyplot as plt
-from src.dao_setup import set_dm_actuators
+from src.utils import set_dm_actuators
 get_ipython().run_line_magic('matplotlib', 'inline')
 from holoeye import detect_heds_module_path  # Move all the example files into the holoeye folder in Lib/site-packages 
 from holoeye import slmdisplaysdk

--- a/src/ao_loop_functions.py
+++ b/src/ao_loop_functions.py
@@ -14,7 +14,8 @@ from PIL import Image
 from matplotlib.colors import LogNorm
 from src.utils import *
 from collections import deque
-from src.dao_setup import init_setup, set_dm_actuators
+from src.dao_setup import init_setup
+from src.utils import set_dm_actuators
 from .shm_loader import shm
 
 setup = init_setup()

--- a/src/calibration_functions.py
+++ b/src/calibration_functions.py
@@ -5,7 +5,7 @@ import time
 import matplotlib.pyplot as plt
 from datetime import datetime
 from src.utils import *
-from src.dao_setup import set_data_dm
+from src.utils import set_data_dm
 from src.dao_setup import init_setup
 from .shm_loader import shm
 

--- a/src/dao_setup.py
+++ b/src/dao_setup.py
@@ -1,5 +1,6 @@
 """Dispatch module for AO bench setup configuration."""
 import os
+from src.utils import set_dm_actuators, set_data_dm
 
 PLACE_OF_TEST = os.environ.get("PLACE_OF_TEST", "Geneva")
 

--- a/src/dao_setup_Geneva.py
+++ b/src/dao_setup_Geneva.py
@@ -18,7 +18,13 @@ from types import SimpleNamespace
 import dao
 from src.config import config
 from src.hardware import Camera, SLM, Laser, DM
-from src.utils import compute_data_slm, set_default_setup, DEFAULT_SETUP
+from src.utils import (
+    compute_data_slm,
+    set_default_setup,
+    DEFAULT_SETUP,
+    set_dm_actuators,
+    set_data_dm,
+)
 from src.shm_loader import shm
 from src.circular_pupil_functions import create_slm_circular_pupil
 
@@ -31,69 +37,6 @@ folder_turbulence = config.folder_turbulence
 folder_gui = config.folder_gui
 
 #%%
-
-def set_dm_actuators(actuators=None, dm_flat=None, setup=None, **kwargs):
-    """Set DM actuators and update the shared memory grid."""
-
-    if setup is None:
-        if DEFAULT_SETUP is None:
-            raise ValueError("No setup provided and no default registered.")
-        setup = DEFAULT_SETUP
-
-    if actuators is None:
-        actuators = np.zeros(setup.nact ** 2)
-    if dm_flat is None:
-        dm_flat = setup.dm_flat
-
-    actuators = np.asarray(actuators)
-
-    deformable_mirror = kwargs.get("deformable_mirror", setup.deformable_mirror)
-    if deformable_mirror is None:
-        raise ValueError("Deformable mirror instance must be provided")
-
-    deformable_mirror.actuators = actuators + dm_flat
-
-    dm_act_shm = shm.dm_act_shm
-    dm_act_shm.set_data(
-        np.asarray(deformable_mirror.actuators).astype(np.float64).reshape(
-            setup.nact, setup.nact
-        )
-    )
-
-
-def set_data_dm(actuators=None, *, setup=None, dm_flat=None, **kwargs):
-    """Flatten the DM, optionally apply ``actuators`` and show the resulting phase on the SLM."""
-
-    if setup is None:
-        if DEFAULT_SETUP is None:
-            raise ValueError("No setup provided and no default registered.")
-        setup = DEFAULT_SETUP
-
-    slm = kwargs.get("slm", setup.slm)
-    if slm is None:
-        raise ValueError("SLM instance must be provided")
-
-    deformable_mirror = kwargs.get("deformable_mirror", setup.deformable_mirror)
-    if deformable_mirror is None:
-        raise ValueError("Deformable mirror instance must be provided")
-
-    npix_small_pupil_grid = kwargs.get(
-        "npix_small_pupil_grid", setup.npix_small_pupil_grid
-    )
-    wait_time = kwargs.get("wait_time", setup.wait_time)
-    pupil_setup = kwargs.get("pupil_setup", setup.pupil_setup)
-
-    deformable_mirror.flatten()
-    set_dm_actuators(actuators, dm_flat=dm_flat, setup=setup)
-
-    data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
-    data_dm[:, :] = deformable_mirror.opd.shaped / 2
-
-    data_slm = compute_data_slm(data_dm=data_dm, setup=pupil_setup)
-    slm.set_data(data_slm)
-    time.sleep(wait_time)
-
-    return actuators, data_dm, data_slm
 
 #%% Start the laser
 

--- a/src/dao_setup_PAPYRUS.py
+++ b/src/dao_setup_PAPYRUS.py
@@ -23,7 +23,13 @@ from types import SimpleNamespace
 import dao
 from src.config import config
 from src.hardware import Camera
-from src.utils import compute_data_slm, set_default_setup, DEFAULT_SETUP
+from src.utils import (
+    compute_data_slm,
+    set_default_setup,
+    DEFAULT_SETUP,
+    set_dm_actuators,
+    set_data_dm,
+)
 from src.shm_loader import shm
 
 ROOT_DIR = config.root_dir
@@ -35,58 +41,6 @@ folder_turbulence = config.folder_turbulence
 folder_gui = config.folder_gui
 
 #%%
-
-def set_dm_actuators(actuators=None, dm_flat=None, setup=None, **kwargs):
-    """Set DM actuators and update the shared memory grid.
-
-    If a deformable mirror instance is available it is updated as well.  When
-    running on a minimal setup (no DM hardware), the actuator pattern is simply
-    written to the shared memory segment.
-    """
-
-    if setup is None:
-        if DEFAULT_SETUP is None:
-            raise ValueError("No setup provided and no default registered.")
-        setup = DEFAULT_SETUP
-
-    if actuators is None:
-        actuators = np.zeros(setup.nact ** 2)
-    if dm_flat is None:
-        dm_flat = setup.dm_flat
-
-    actuators = np.asarray(actuators)
-
-    
-    actuators_to_apply = actuators + dm_flat
-
-    dm_act_shm = shm.dm_act_shm
-    dm_act_shm.set_data(
-        np.asarray(actuators_to_apply).astype(np.float64).reshape(
-            setup.nact, setup.nact
-        )
-    )
-
-
-def set_data_dm(actuators=None, *, setup=None, dm_flat=None, **kwargs):
-    """Flatten the DM, optionally apply ``actuators`` and, if available, update the SLM."""
-
-    if setup is None:
-        if DEFAULT_SETUP is None:
-            raise ValueError("No setup provided and no default registered.")
-        setup = DEFAULT_SETUP
-
-   
-    wait_time = kwargs.get("wait_time", getattr(setup, "wait_time", 0))
-    pupil_setup = kwargs.get("pupil_setup", getattr(setup, "pupil_setup", None))
-
-    set_dm_actuators(actuators, dm_flat=dm_flat, setup=setup, )
-
-    data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
-    
-    data_slm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
- 
-
-    return actuators, data_dm, None
 
 #%% Configuration Camera
 

--- a/src/flux_filtering_mask_functions.py
+++ b/src/flux_filtering_mask_functions.py
@@ -12,7 +12,7 @@ import os
 from matplotlib import pyplot as plt
 from src.dao_setup import init_setup
 from src.tilt_functions import apply_intensity_tilt_kl
-from src.dao_setup import set_data_dm
+from src.utils import set_data_dm
 from astropy.io import fits
 
 setup = init_setup()

--- a/src/psf_centring_algorithm_functions.py
+++ b/src/psf_centring_algorithm_functions.py
@@ -6,7 +6,7 @@ import cv2
 import re
 
 from src.config import config
-from src.dao_setup import set_data_dm
+from src.utils import set_data_dm
 
 ROOT_DIR = config.root_dir
 

--- a/src/scan_modes_functions.py
+++ b/src/scan_modes_functions.py
@@ -9,7 +9,7 @@ camera_fp = setup.camera_fp
 camera_wfs = setup.camera_wfs
 from pathlib import Path
 import re
-from src.dao_setup import set_data_dm
+from src.utils import set_data_dm
 
 
 def scan_othermode_amplitudes(test_values, mode_index,

--- a/src/utils.py
+++ b/src/utils.py
@@ -56,6 +56,111 @@ def compute_data_slm(data_dm=0, data_phase_screen=0, data_dm_flat=0, setup=None,
 
     return data_slm.astype(np.uint8)
 
+
+def set_dm_actuators(
+    actuators=None,
+    dm_flat=None,
+    setup=None,
+    *,
+    place_of_test=None,
+    **kwargs,
+):
+    """Update DM actuators and the corresponding shared memory grid.
+
+    When running on the Geneva bench the underlying ``deformable_mirror``
+    hardware is updated as well.  On setups without a physical DM the
+    function simply writes the actuator pattern to the shared memory.
+    The ``PLACE_OF_TEST`` environment variable is inspected to determine
+    which behaviour to use (defaults to ``"Geneva"``).
+    """
+
+    if setup is None:
+        if DEFAULT_SETUP is None:
+            raise ValueError("No setup provided and no default registered.")
+        setup = DEFAULT_SETUP
+
+    if place_of_test is None:
+        place_of_test = os.environ.get("PLACE_OF_TEST", "Geneva")
+
+    if actuators is None:
+        actuators = np.zeros(setup.nact ** 2)
+    if dm_flat is None:
+        dm_flat = setup.dm_flat
+
+    actuators = np.asarray(actuators)
+
+    if place_of_test == "Geneva":
+        deformable_mirror = kwargs.get(
+            "deformable_mirror", getattr(setup, "deformable_mirror", None)
+        )
+        if deformable_mirror is None:
+            raise ValueError("Deformable mirror instance must be provided")
+        deformable_mirror.actuators = actuators + dm_flat
+        actuators_to_store = deformable_mirror.actuators
+    else:
+        # No DM hardware available
+        actuators_to_store = actuators + dm_flat
+
+    dm_act_shm = shm.dm_act_shm
+    dm_act_shm.set_data(
+        np.asarray(actuators_to_store).astype(np.float64).reshape(setup.nact, setup.nact)
+    )
+
+
+def set_data_dm(
+    actuators=None,
+    *,
+    setup=None,
+    dm_flat=None,
+    place_of_test=None,
+    **kwargs,
+):
+    """Flatten the DM, optionally apply ``actuators`` and update the SLM."""
+
+    if setup is None:
+        if DEFAULT_SETUP is None:
+            raise ValueError("No setup provided and no default registered.")
+        setup = DEFAULT_SETUP
+
+    if place_of_test is None:
+        place_of_test = os.environ.get("PLACE_OF_TEST", "Geneva")
+
+    npix_small_pupil_grid = kwargs.get(
+        "npix_small_pupil_grid", getattr(setup, "npix_small_pupil_grid", 0)
+    )
+    wait_time = kwargs.get("wait_time", getattr(setup, "wait_time", 0))
+    pupil_setup = kwargs.get("pupil_setup", getattr(setup, "pupil_setup", None))
+    slm = kwargs.get("slm", getattr(setup, "slm", None))
+    deformable_mirror = kwargs.get(
+        "deformable_mirror", getattr(setup, "deformable_mirror", None)
+    )
+
+    if place_of_test == "Geneva":
+        if slm is None:
+            raise ValueError("SLM instance must be provided")
+        if deformable_mirror is None:
+            raise ValueError("Deformable mirror instance must be provided")
+
+        deformable_mirror.flatten()
+        set_dm_actuators(
+            actuators, dm_flat=dm_flat, setup=setup, place_of_test=place_of_test, deformable_mirror=deformable_mirror
+        )
+
+        data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
+        data_dm[:, :] = deformable_mirror.opd.shaped / 2
+
+        data_slm = compute_data_slm(data_dm=data_dm, setup=pupil_setup)
+        slm.set_data(data_slm)
+        time.sleep(wait_time)
+        return actuators, data_dm, data_slm
+
+    # Minimal setup: only update shared memory
+    set_dm_actuators(
+        actuators, dm_flat=dm_flat, setup=setup, place_of_test=place_of_test
+    )
+    data_dm = np.zeros((npix_small_pupil_grid, npix_small_pupil_grid), dtype=np.float32)
+    return actuators, data_dm, None
+
 def create_psf_mask(psf, crop_size=100, radius=50):
     """
     Creates a mask for the PSF image by cropping a region around the center,


### PR DESCRIPTION
## Summary
- centralize `set_dm_actuators` and `set_data_dm` in `src.utils`
- use env var `PLACE_OF_TEST` to choose behaviour
- remove duplicated helpers from the setup modules
- update setup modules and scripts to import helpers from `src.utils`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688853898454833080dc48aa773fdf82