### PR TITLE
Fix DM initialization for PAPYRUS

### DIFF
--- a/src/dao_setup_PAPYRUS.py
+++ b/src/dao_setup_PAPYRUS.py
@@ -141,11 +141,12 @@ data_othermodes = np.sum(othermodes_matrix, axis=0)
 dm_flat = data_tt + data_othermodes
 _setup = SimpleNamespace(
     nact=nact,
+    nact_valid=nact_valid,
     dm_flat=dm_flat,
     dm_map=dm_map,
     dm_papy_shm=dm_papy_shm,
 )
-set_dm_actuators(dm_flat=dm_flat, setup=_setup)
+set_dm_actuators(actuators=dm_flat[dm_map], setup=_setup)
 
 
 class PupilSetup:


### PR DESCRIPTION
## Summary
- fix actuator initialization in `dao_setup_PAPYRUS`
- ensure valid actuator count is provided and pass filtered array to `set_dm_actuators`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_68894befe7048330935ae82007ed05bb