### PR TITLE
Relocate reload_setup helper

### DIFF
--- a/scripts_with_dao/dao_calibrations_file.py
+++ b/scripts_with_dao/dao_calibrations_file.py
@@ -18,29 +18,8 @@ import importlib
 # Import Specific Modules
 import dao
 from src.dao_setup import init_setup, las
-from src.utils import set_data_dm
+from src.utils import set_data_dm, reload_setup
 setup = init_setup()
-
-
-def reload_setup():
-    """Reload ``src.dao_setup`` and return a fresh setup instance."""
-    import importlib
-    import src.dao_setup as dao_setup
-
-    if dao_setup.PLACE_OF_TEST == "Geneva":
-        import src.dao_setup_Geneva as ds_mod
-    else:
-        import src.dao_setup_PAPYRUS as ds_mod
-
-    importlib.reload(ds_mod)
-    importlib.reload(dao_setup)
-
-    global setup, las
-    from src.dao_setup import init_setup as _init_setup, las as _las
-
-    setup = _init_setup()
-    las = _las
-    return setup
 
 from src.config import config
 from src.utils import *

--- a/src/utils.py
+++ b/src/utils.py
@@ -20,6 +20,26 @@ def set_default_setup(setup):
     """Register a default setup used when none is provided."""
     global DEFAULT_SETUP
     DEFAULT_SETUP = setup
+
+
+def reload_setup():
+    """Reload ``src.dao_setup`` and return a fresh setup instance."""
+    import importlib
+    import src.dao_setup as dao_setup
+
+    if dao_setup.PLACE_OF_TEST == "Geneva":
+        import src.dao_setup_Geneva as ds_mod
+    else:
+        import src.dao_setup_PAPYRUS as ds_mod
+
+    importlib.reload(ds_mod)
+    importlib.reload(dao_setup)
+
+    global DEFAULT_SETUP
+    from src.dao_setup import init_setup as _init_setup
+
+    DEFAULT_SETUP = _init_setup()
+    return DEFAULT_SETUP
     
     
 def _resolve_place_of_test(place_of_test):


### PR DESCRIPTION
## Summary
- centralize reload_setup in utils for reuse
- import helper in dao_calibrations_file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b3f0ea0b48330a7ded0b4108aac4d