### PR TITLE
Add OnSky suffix for flux mask outputs

### DIFF
--- a/scripts_with_dao/dao_AO_open_loop_with_kl_3s_pyr_papyrus.py
+++ b/scripts_with_dao/dao_AO_open_loop_with_kl_3s_pyr_papyrus.py
@@ -50,6 +50,10 @@ camera_wfs = setup.camera_wfs
 camera_fp = setup.camera_fp
 npix_small_pupil_grid = setup.npix_small_pupil_grid
 
+# Flag to identify on-sky data
+OnSky = False
+suffix = "_OnSky" if OnSky else ""
+
 #%% Creating and Displaying a Circular Pupil on the SLM
 
 #DM set to flat
@@ -73,7 +77,7 @@ print(f"Bias image shape: {bias_image.shape}")
 bias_image=np.zeros_like(bias_image)
 
 # Load the calibration mask for processing images.
-mask_filename = f'mask_3s_pyr.fits'
+mask_filename = f'mask_3s_pyr{suffix}.fits'
 mask = fits.getdata(os.path.join(folder_calib, mask_filename))
 print(f"Mask dimensions: {mask.shape}")
 

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
@@ -36,6 +36,10 @@ camera_wfs = setup.camera_wfs
 camera_fp = setup.camera_fp
 npix_small_pupil_grid = setup.npix_small_pupil_grid
 
+# Flag to identify on-sky data
+OnSky = False
+suffix = "_OnSky" if OnSky else ""
+
 #%% Creating and Displaying a Circular Pupil on the SLM
 
 #DM set to flat
@@ -59,7 +63,7 @@ print(f"Bias image shape: {bias_image.shape}")
 bias_image=np.zeros_like(bias_image)
 
 # Load the calibration mask for processing images.
-mask_filename = f'mask_3s_pyr.fits'
+mask_filename = f'mask_3s_pyr{suffix}.fits'
 mask = fits.getdata(os.path.join(folder_calib, mask_filename))
 print(f"Mask dimensions: {mask.shape}")
 

--- a/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
@@ -36,10 +36,6 @@ camera_wfs = setup.camera_wfs
 camera_fp = setup.camera_fp
 npix_small_pupil_grid = setup.npix_small_pupil_grid
 
-# Flag to identify on-sky data
-OnSky = False
-suffix = "_OnSky" if OnSky else ""
-
 #%% Creating and Displaying a Circular Pupil on the SLM
 
 #DM set to flat
@@ -63,7 +59,7 @@ print(f"Bias image shape: {bias_image.shape}")
 bias_image=np.zeros_like(bias_image)
 
 # Load the calibration mask for processing images.
-mask_filename = f'mask_3s_pyr{suffix}.fits'
+mask_filename = f'mask_3s_pyr.fits'
 mask = fits.getdata(os.path.join(folder_calib, mask_filename))
 print(f"Mask dimensions: {mask.shape}")
 

--- a/src/flux_filtering_mask_functions.py
+++ b/src/flux_filtering_mask_functions.py
@@ -117,8 +117,12 @@ def create_summed_image_for_mask_dm_random(n_iter, verbose=False, **kwargs):
 
 def create_flux_filtering_mask(method, flux_cutoff, tiltx, tilty,
                                modulation_angles=np.arange(0, 360, 10), modulation_amp=15, n_iter=200,
-                               create_summed_image=True, verbose=False, verbose_plot=False, **kwargs):
+                               create_summed_image=True, verbose=False, verbose_plot=False,
+                               OnSky=False, **kwargs):
     """Generate a binary mask highlighting high-flux regions.
+
+    When ``OnSky=True`` the string ``'_OnSky'`` is appended to the output
+    filenames instead of producing an additional file.
 
     Parameters
     ----------
@@ -140,6 +144,8 @@ def create_flux_filtering_mask(method, flux_cutoff, tiltx, tilty,
         Print progress information.
     verbose_plot : bool, optional
         Display intermediate plots.
+    OnSky : bool, optional
+        If ``True`` append ``'_OnSky'`` to output filenames.
     **kwargs : optional
         ``camera`` and ``nact_total`` passed to image acquisition functions,
         ``folder_pyr_mask`` and ``folder_calib`` to override output locations.
@@ -153,7 +159,8 @@ def create_flux_filtering_mask(method, flux_cutoff, tiltx, tilty,
     folder_pyr_mask = kwargs.get("folder_pyr_mask", setup.folder_pyr_mask)
     folder_calib = kwargs.get("folder_calib", setup.folder_calib)
 
-    summed_img_path = os.path.join(folder_calib, f'summed_pyr_images_3s_pyr.fits')
+    suffix = "_OnSky" if OnSky else ""
+    summed_img_path = os.path.join(folder_calib, f'summed_pyr_images_3s_pyr{suffix}.fits')
 
     if create_summed_image:
         if verbose:
@@ -217,11 +224,11 @@ def create_flux_filtering_mask(method, flux_cutoff, tiltx, tilty,
         print('Saving masked image and mask')
 
     fits.writeto(
-        os.path.join(folder_calib, f'masked_pyr_images_3s_pyr.fits'),
+        os.path.join(folder_calib, f'masked_pyr_images_3s_pyr{suffix}.fits'),
         masked_summed_image.astype(np.float32), overwrite=True
     )
     fits.writeto(
-        os.path.join(folder_calib, f'mask_3s_pyr.fits'),
+        os.path.join(folder_calib, f'mask_3s_pyr{suffix}.fits'),
         mask.astype(np.uint8), overwrite=True
     )
 


### PR DESCRIPTION
## Summary
- Extend flux filtering mask generation to support an `OnSky` flag, appending `_OnSky` to FITS outputs
- Update calibration scripts to read masks using the new suffix convention

## Testing
- `python -m py_compile src/flux_filtering_mask_functions.py scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py scripts_with_dao/dao_AO_open_loop_with_kl_3s_pyr_papyrus.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dao')*

------
https://chatgpt.com/codex/tasks/task_e_6890795b87688330b63d31d03428b264