### PR TITLE
Save linearity curves with timestamped copies

### DIFF
--- a/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 from astropy.io import fits
 import scipy
 from matplotlib.colors import LogNorm
+from datetime import datetime
 
 # Import Specific Modules
 from src.config import config
@@ -166,11 +167,18 @@ plt.tight_layout()
 
 
 # Save to file
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 save_path = folder_calib / "linearity_curves.png"
+timestamped_save_path = folder_calib / f"linearity_curves_{timestamp}.png"
 plt.savefig(save_path, dpi=300)
+plt.savefig(timestamped_save_path, dpi=300)
 plt.show()
 
-print(f"Linearity curves saved to: {save_path}")
+print(
+    "Linearity curves saved to:"
+    f"\n - {save_path}"
+    f"\n - {timestamped_save_path}"
+)
 
 #DM set to flat
 set_data_dm(setup=setup)


### PR DESCRIPTION
## Summary
- import `datetime` so linearity curve exports can be timestamped
- save the linearity curves plot to both the default filename and an additional timestamped copy
- update the operator message to enumerate both saved file locations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69172fb308330b892ee1778f3c56a