### PR TITLE
Add timestamped FITS output for cross-correlation matrix

### DIFF
--- a/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
+++ b/scripts_with_dao/dao_linearity_curve_3s_pyr_papyrus.py
@@ -239,12 +239,21 @@ plt.savefig(crosscorr_png_timestamped_path, dpi=300)
 plt.show()
 
 # Save cross-correlation matrix as FITS
-fits_path = folder_calib / f"crosscorrelation_matrix.fits"
-fits.writeto(fits_path, crosscorrelation_matrix, overwrite=True)
+crosscorr_fits_path = folder_calib / "crosscorrelation_matrix.fits"
+crosscorr_fits_timestamped_path = (
+    folder_calib / f"crosscorrelation_matrix_{crosscorr_timestamp}.fits"
+)
+fits.writeto(crosscorr_fits_path, crosscorrelation_matrix, overwrite=True)
+fits.writeto(
+    crosscorr_fits_timestamped_path, crosscorrelation_matrix, overwrite=True
+)
 
 print(
-    "Cross-correlation matrix saved to: "
-    f"{crosscorr_png_path}, {crosscorr_png_timestamped_path}, {fits_path}"
+    "Cross-correlation matrix saved to:"
+    f"\n - {crosscorr_png_path}"
+    f"\n - {crosscorr_png_timestamped_path}"
+    f"\n - {crosscorr_fits_path}"
+    f"\n - {crosscorr_fits_timestamped_path}"
 )
 
 #DM set to flat


### PR DESCRIPTION
## Summary
- add a timestamped FITS filename when saving the cross-correlation matrix
- extend the logging to list both PNG and FITS outputs in a consistent format

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d694f792d483308f201aa68e51e293